### PR TITLE
OKTA-362449: code verifier improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,24 +103,25 @@ IDXClient client = Clients.builder()
 ```
 [//]: # (end: createClient)
 
-### Get Interaction Handle
-
-[//]: # (method: getInteractionHandle)
-```java
-InteractResponse interactResponse = client.interact();
-String interactHandle = interactResponse.getInteractionHandle();
-```
-[//]: # (end: getInteractionHandle)
-
 ### Get State Handle
 
 [//]: # (method: exchangeInteractionHandleForStateHandle)
 ```java
-// optional with interactionHandle or empty; if empty, a new interactionHandle will be obtained
-IDXResponse idxResponse = client.introspect(Optional.of("{interactHandle}"));
+IDXClientContext idxClientContext = client.interact();
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 ```
 [//]: # (end: exchangeInteractionHandleForStateHandle)
+
+### Get Interaction Handle and Code Verifier
+
+[//]: # (method: getInteractionHandleAndCodeVerifier)
+```java
+IDXClientContext idxClientContext = client.interact();
+String interactionHandle = idxClientContext.getInteractionHandle();
+String codeVerifier = idxClientContext.getCodeVerifier();
+```
+[//]: # (end: getInteractionHandleAndCodeVerifier)
 
 ### Get New tokens (access_token/id_token/refresh_token)
 
@@ -139,8 +140,11 @@ IDXClient client = Clients.builder()
         .setRedirectUri("{redirectUri}") // must match the redirect uri in client app settings/console
         .build();
 
-// call introspect - interactionHandle is optional; if it's not provided, a new interactionHandle will be obtained.IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
-IDXResponse idxResponse = client.introspect(Optional.empty());
+// get client context
+IDXClientContext idxClientContext = client.interact();
+
+// introspect
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 
 // check remediation options to continue the flow
@@ -199,7 +203,7 @@ AnswerChallengeRequest passwordAuthenticatorAnswerChallengeRequest = AnswerChall
 idxResponse = remediationOption.proceed(client, passwordAuthenticatorAnswerChallengeRequest);
 
 // exchange interaction code for token
-TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
 log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
         tokenResponse.getAccessToken(),
         tokenResponse.getIdToken(),
@@ -225,12 +229,11 @@ IDXClient client = Clients.builder()
         .setRedirectUri("{redirectUri}") // must match the redirect uri in client app settings/console
         .build();
 
-// get interactionHandle
-InteractResponse interactResponse = client.interact();
-String interactHandle = interactResponse.getInteractionHandle();
+// get client context
+IDXClientContext idxClientContext = client.interact();
 
 // exchange interactHandle for stateHandle
-IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 
 // check remediation options to continue the flow
@@ -312,8 +315,11 @@ In this example, the Org is configured to require a security question as a secon
 
 [//]: # (method: loginUsingPasswordAndEnrollSecQnAuthenticator)
 ```java
+// get client context
+IDXClientContext idxClientContext = client.interact();
+
 // introspect
-IDXResponse idxResponse = client.introspect(Optional.of("{interactHandle}"));
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 Credentials credentials = new Credentials();
 credentials.setPasscode("{password}".toCharArray());
@@ -399,12 +405,11 @@ In this example, the Org is configured to require an email as a second authentic
 
 [//]: # (method: loginUsingPasswordAndEmailAuthenticator)
 ```java
-// get interactionHandle
-InteractResponse interactResponse = client.interact();
-String interactHandle = interactResponse.getInteractionHandle();
+// get client context
+IDXClientContext idxClientContext = client.interact();
 
 // exchange interactHandle for stateHandle
-IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 
 // check remediation options to continue the flow
@@ -507,7 +512,7 @@ idxResponse = remediationOption.proceed(client, emailAuthenticatorAnswerChalleng
 if (idxResponse.isLoginSuccessful()) {
     log.info("Login Successful!");
     // exchange the received interaction code for a token
-    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
             tokenResponse.getAccessToken(),
             tokenResponse.getIdToken(),
@@ -527,12 +532,11 @@ In this example, the Org is configured to require a Phone factor (SMS/Voice) as 
 
 [//]: # (method: loginUsingPasswordAndPhoneAuthenticator)
 ```java
-// get interactionHandle
-InteractResponse interactResponse = client.interact();
-String interactHandle = interactResponse.getInteractionHandle();
+// get client context
+IDXClientContext idxClientContext = client.interact();
 
 // exchange interactHandle for stateHandle
-IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 IdentifyRequest identifyRequest = IdentifyRequestBuilder.builder()
         .withIdentifier("{identifier}") // email
@@ -632,7 +636,7 @@ idxResponse = remediationOption.proceed(client, passwordAuthenticatorAnswerChall
 // check if we landed success on login
 if (idxResponse.isLoginSuccessful()) {
     log.info("Login Successful!");
-    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
             tokenResponse.getAccessToken(),
             tokenResponse.getIdToken(),
@@ -654,12 +658,11 @@ Refer [here](https://developer.okta.com/docs/reference/api/authn/#get-the-signed
 
 [//]: # (method: loginUsingPasswordAndWebAuthnAuthenticator)
 ```java
-// get interactionHandle
-InteractResponse interactResponse = client.interact();
-String interactHandle = interactResponse.getInteractionHandle();
+// get client context
+IDXClientContext idxClientContext = client.interact();
 
 // exchange interactHandle for stateHandle
-IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 
 // check remediation options to continue the flow
@@ -767,7 +770,7 @@ idxResponse = remediationOption.proceed(client, fingerprintAuthenticatorAnswerCh
 // check if we landed success on login
 if (idxResponse.isLoginSuccessful()) {
     log.info("Login Successful!");
-    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
             tokenResponse.getAccessToken(),
             tokenResponse.getIdToken(),
@@ -787,12 +790,11 @@ In this example, the Org is configured to require password authenticator to logi
 
 [//]: # (method: loginWithPasswordReset)
 ```java
-// get interactionHandle
-InteractResponse interactResponse = client.interact();
-String interactHandle = interactResponse.getInteractionHandle();
+// get client context
+IDXClientContext idxClientContext = client.interact();
 
 // exchange interactHandle for stateHandle
-IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 
 // check remediation options to continue the flow
@@ -815,8 +817,7 @@ RecoverRequest recoverRequest = RecoverRequestBuilder.builder()
         .build();
 idxResponse = remediationOption.proceed(client, recoverRequest);
 
-// get remediation options to go to the next step
-// since the org requires password only, we don't have the "select password authenticator" step as in previous examples 
+// since the org requires password only, we don't have the "select password authenticator" step as in previous examples
 remediationOptions = idxResponse.remediation().remediationOptions();
 remediationOptionsOptional = Arrays.stream(remediationOptions)
         .filter(x -> "challenge-authenticator".equals(x.getName()))
@@ -855,14 +856,13 @@ passwordAuthenticatorAnswerChallengeRequest = AnswerChallengeRequestBuilder.buil
         .withStateHandle(stateHandle)
         .withCredentials(credentials)
         .build();
-
 idxResponse = remediationOption.proceed(client, passwordAuthenticatorAnswerChallengeRequest);
 
 // check if we landed success on login
 if (idxResponse.isLoginSuccessful()) {
     log.info("Login Successful!");
     // exchange the received interaction code for a token
-    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
             tokenResponse.getAccessToken(),
             tokenResponse.getIdToken(),
@@ -897,12 +897,11 @@ Sign up a new user.
 
 [//]: # (method: registrationFlow)
 ```java
-// get interactionHandle
-InteractResponse interactResponse = client.interact();
-String interactHandle = interactResponse.getInteractionHandle();
+// get client context
+IDXClientContext idxClientContext = client.interact();
 
 // exchange interactHandle for stateHandle
-IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+IDXResponse idxResponse = client.introspect(idxClientContext);
 String stateHandle = idxResponse.getStateHandle();
 
 // get remediation options to go to the next step
@@ -1109,7 +1108,7 @@ idxResponse = remediationOption.proceed(client, skipAuthenticatorEnrollmentReque
 // This response should contain the interaction code
 if (idxResponse.isLoginSuccessful()) {
     log.info("Login Successful!");
-    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
             tokenResponse.getAccessToken(),
             tokenResponse.getIdToken(),

--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXClient.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXClient.java
@@ -16,6 +16,7 @@
 package com.okta.idx.sdk.api.client;
 
 import com.okta.idx.sdk.api.exception.ProcessingException;
+import com.okta.idx.sdk.api.model.IDXClientContext;
 import com.okta.idx.sdk.api.request.AnswerChallengeRequest;
 import com.okta.idx.sdk.api.request.ChallengeRequest;
 import com.okta.idx.sdk.api.request.EnrollRequest;
@@ -24,19 +25,16 @@ import com.okta.idx.sdk.api.request.IdentifyRequest;
 import com.okta.idx.sdk.api.request.SkipAuthenticatorEnrollmentRequest;
 import com.okta.idx.sdk.api.request.RecoverRequest;
 import com.okta.idx.sdk.api.response.IDXResponse;
-import com.okta.idx.sdk.api.response.InteractResponse;
 import com.okta.idx.sdk.api.response.TokenResponse;
-
-import java.util.Optional;
 
 /**
  * Client to interact with the IDX backend APIs.
  */
 public interface IDXClient {
 
-    InteractResponse interact() throws ProcessingException;
+    IDXClientContext interact() throws ProcessingException;
 
-    IDXResponse introspect(Optional<String> interactionHandleOptional) throws ProcessingException;
+    IDXResponse introspect(IDXClientContext idxClientContext) throws ProcessingException;
 
     IDXResponse identify(IdentifyRequest identifyRequest, String href) throws ProcessingException;
 
@@ -54,5 +52,5 @@ public interface IDXClient {
 
     IDXResponse recover(RecoverRequest recoverRequest, String href) throws ProcessingException;
 
-    TokenResponse token(String url, String grantType, String interactionCode) throws ProcessingException;
+    TokenResponse token(String url, String grantType, String interactionCode, IDXClientContext idxClientContext) throws ProcessingException;
 }

--- a/api/src/main/java/com/okta/idx/sdk/api/model/IDXClientContext.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/IDXClientContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.idx.sdk.api.model;
+
+public class IDXClientContext {
+
+    private String codeVerifier;
+
+    private String interactionHandle;
+
+    private String state;
+
+    public IDXClientContext(String codeVerifier, String interactionHandle, String state) {
+        this.codeVerifier = codeVerifier;
+        this.interactionHandle = interactionHandle;
+        this.state = state;
+    }
+
+    public String getCodeVerifier() {
+        return codeVerifier;
+    }
+
+    public String getInteractionHandle() {
+        return interactionHandle;
+    }
+
+    public String getState() {
+        return state;
+    }
+}

--- a/api/src/main/java/com/okta/idx/sdk/api/model/SuccessResponse.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/SuccessResponse.java
@@ -116,10 +116,10 @@ public class SuccessResponse {
      * @param client the idx client instance
      * @return TokenResponse
      */
-    public TokenResponse exchangeCode(IDXClient client) throws ProcessingException {
+    public TokenResponse exchangeCode(IDXClient client, IDXClientContext idxClientContext) throws ProcessingException {
         String grantType = this.parseGrantType();
         String interactionCode = this.parseInteractionCode();
         String tokenUrl = this.getHref();
-        return client.token(tokenUrl, grantType, interactionCode);
+        return client.token(tokenUrl, grantType, interactionCode, idxClientContext);
     }
 }

--- a/examples/src/main/java/Quickstart.java
+++ b/examples/src/main/java/Quickstart.java
@@ -21,6 +21,7 @@ import com.okta.idx.sdk.api.exception.ProcessingException;
 import com.okta.idx.sdk.api.model.Authenticator;
 import com.okta.idx.sdk.api.model.Credentials;
 import com.okta.idx.sdk.api.model.FormValue;
+import com.okta.idx.sdk.api.model.IDXClientContext;
 import com.okta.idx.sdk.api.model.Options;
 import com.okta.idx.sdk.api.model.RemediationOption;
 import com.okta.idx.sdk.api.model.UserProfile;
@@ -39,7 +40,6 @@ import com.okta.idx.sdk.api.request.SkipAuthenticatorEnrollmentRequest;
 import com.okta.idx.sdk.api.request.SkipAuthenticatorEnrollmentRequestBuilder;
 import com.okta.idx.sdk.api.request.RecoverRequestBuilder;
 import com.okta.idx.sdk.api.response.IDXResponse;
-import com.okta.idx.sdk.api.response.InteractResponse;
 import com.okta.idx.sdk.api.response.TokenResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,10 +59,10 @@ public class Quickstart {
 
     private static final IDXClient client = Clients.builder().build();
 
-    private static final String IDENTIFIER = "someone@example.com";                                           // replace
-    private static final char[] PASSWORD = {'T','o','p','s','e','c','r','e','t','1','2','3','!'};             // replace
-    private static final char[] NEW_PASSWORD = {'S','u','p','e','r','s','e','c','r','e','t','1','2','3','!'}; // replace
-    private static final char[] SECURITY_QUESTION_ANSWER = { 'O','k','t','a'};                                // replace
+    private static final String IDENTIFIER = "someone@example.com";                   // replace
+    private static final char[] PASSWORD = "Topsecret123!".toCharArray();             // replace
+    private static final char[] NEW_PASSWORD = "Supersecret123!".toCharArray();       // replace
+    private static final char[] SECURITY_QUESTION_ANSWER = "Okta".toCharArray();      // replace
 
     public static void main(String... args) throws JsonProcessingException {
 
@@ -89,6 +89,7 @@ public class Quickstart {
         // complete login flow with password and webauthn
         //runLoginFlowWithPasswordAndWebAuthnAuthenticators();
 
+        // complete reset password flow
         //runLoginFlowWithPasswordReset();
 
         // complete registration flow for new user (Sign Up)
@@ -98,12 +99,11 @@ public class Quickstart {
     private static void runRegistrationFlow() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // get remediation options to go to the next step
@@ -319,7 +319,7 @@ public class Quickstart {
             // This response should contain the interaction code
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                         tokenResponse.getAccessToken(),
                         tokenResponse.getIdToken(),
@@ -336,12 +336,11 @@ public class Quickstart {
     private static void runEnrollSecurityQnAuthenticatorFlow() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -387,7 +386,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Token: {}", tokenResponse);
             } else {
                 // logon is not successful yet; we need to follow more remediation steps.
@@ -437,7 +436,7 @@ public class Quickstart {
                 // check if we landed success on login
                 if (idxResponse.isLoginSuccessful()) {
                     log.info("Login Successful!");
-                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                             tokenResponse.getAccessToken(),
                             tokenResponse.getIdToken(),
@@ -498,7 +497,7 @@ public class Quickstart {
                     if (idxResponse.isLoginSuccessful()) {
                         log.info("Login Successful!");
                         // exchange the received interaction code for a token
-                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                         log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                                 tokenResponse.getAccessToken(),
                                 tokenResponse.getIdToken(),
@@ -574,12 +573,11 @@ public class Quickstart {
     private static void runLoginFlowWithPasswordAndEmailAuthenticators() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -625,7 +623,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Token: {}", tokenResponse);
             } else {
                 // logon is not successful yet; we need to follow more remediation steps.
@@ -675,7 +673,7 @@ public class Quickstart {
                 // check if we landed success on login
                 if (idxResponse.isLoginSuccessful()) {
                     log.info("Login Successful!");
-                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                             tokenResponse.getAccessToken(),
                             tokenResponse.getIdToken(),
@@ -736,7 +734,7 @@ public class Quickstart {
                     if (idxResponse.isLoginSuccessful()) {
                         log.info("Login Successful!");
                         // exchange the received interaction code for a token
-                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                         log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                                 tokenResponse.getAccessToken(),
                                 tokenResponse.getIdToken(),
@@ -755,12 +753,11 @@ public class Quickstart {
     private static void runLoginFlowWithPasswordAndProgressiveProfiling() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -801,7 +798,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                         tokenResponse.getAccessToken(),
                         tokenResponse.getIdToken(),
@@ -838,7 +835,7 @@ public class Quickstart {
 
                 if (idxResponse.isLoginSuccessful()) {
                     log.info("Login Successful!");
-                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                             tokenResponse.getAccessToken(),
                             tokenResponse.getIdToken(),
@@ -856,12 +853,11 @@ public class Quickstart {
     private static void runLoginFlowWithOptionalAuthenticatorEnrollment() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -907,7 +903,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Token: {}", tokenResponse);
             } else {
                 // logon is not successful yet; we need to follow more remediation steps.
@@ -934,7 +930,7 @@ public class Quickstart {
                 // check if we landed success on login
                 if (idxResponse.isLoginSuccessful()) {
                     log.info("Login Successful!");
-                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                             tokenResponse.getAccessToken(),
                             tokenResponse.getIdToken(),
@@ -1018,7 +1014,7 @@ public class Quickstart {
                     // This response should contain the interaction code
                     if (idxResponse.isLoginSuccessful()) {
                         log.info("Login Successful!");
-                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                         log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                                 tokenResponse.getAccessToken(),
                                 tokenResponse.getIdToken(),
@@ -1037,12 +1033,11 @@ public class Quickstart {
     private static void runLoginFlowWithSecurityQnAndEmailAuthenticators() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -1088,7 +1083,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Token: {}", tokenResponse);
             } else {
                 // login is not successful yet; we need to follow more remediation steps.
@@ -1138,7 +1133,7 @@ public class Quickstart {
                 // check if we landed success on login
                 if (idxResponse.isLoginSuccessful()) {
                     log.info("Login Successful!");
-                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                             tokenResponse.getAccessToken(),
                             tokenResponse.getIdToken(),
@@ -1199,7 +1194,7 @@ public class Quickstart {
                     if (idxResponse.isLoginSuccessful()) {
                         log.info("Login Successful!");
                         // exchange the received interaction code for a token
-                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                         log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                                 tokenResponse.getAccessToken(),
                                 tokenResponse.getIdToken(),
@@ -1218,12 +1213,11 @@ public class Quickstart {
     private static void runLoginFlowWithPasswordAndPhoneAuthenticators() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -1269,7 +1263,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Token: {}", tokenResponse);
             } else {
                 // logon is not successful yet; we need to follow more remediation steps.
@@ -1366,7 +1360,7 @@ public class Quickstart {
                 // check if we landed success on login
                 if (idxResponse.isLoginSuccessful()) {
                     log.info("Login Successful!");
-                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                             tokenResponse.getAccessToken(),
                             tokenResponse.getIdToken(),
@@ -1384,12 +1378,11 @@ public class Quickstart {
     private static void runLoginFlowWithPasswordAndWebAuthnAuthenticators() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -1493,7 +1486,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                         tokenResponse.getAccessToken(),
                         tokenResponse.getIdToken(),
@@ -1510,12 +1503,11 @@ public class Quickstart {
     private static void runLoginFlowWithPasswordReset() throws JsonProcessingException {
 
         try {
-            // get interactionHandle
-            InteractResponse interactResponse = client.interact();
-            String interactHandle = interactResponse.getInteractionHandle();
+            // get client context
+            IDXClientContext idxClientContext = client.interact();
 
-            // exchange interactHandle for stateHandle
-            IDXResponse idxResponse = client.introspect(Optional.of(interactHandle));
+            // get stateHandle
+            IDXResponse idxResponse = client.introspect(idxClientContext);
             String stateHandle = idxResponse.getStateHandle();
 
             // check remediation options to continue the flow
@@ -1561,7 +1553,7 @@ public class Quickstart {
             // check if we landed success on login
             if (idxResponse.isLoginSuccessful()) {
                 log.info("Login Successful!");
-                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                 log.info("Token: {}", tokenResponse);
             } else {
                 // logon is not successful yet; we need to follow more remediation steps.
@@ -1585,17 +1577,17 @@ public class Quickstart {
                 secQnEnrollmentCredentials.setQuestionKey("disliked_food");
                 secQnEnrollmentCredentials.setAnswer(SECURITY_QUESTION_ANSWER);
 
-                // build answer password authenticator challenge request
-                AnswerChallengeRequest passwordAuthenticatorAnswerChallengeRequest = AnswerChallengeRequestBuilder.builder()
+                // build answer security question authenticator challenge request
+                AnswerChallengeRequest answerChallengeRequest = AnswerChallengeRequestBuilder.builder()
                         .withStateHandle(stateHandle)
                         .withCredentials(secQnEnrollmentCredentials)
                         .build();
-                idxResponse = remediationOption.proceed(client, passwordAuthenticatorAnswerChallengeRequest);
+                idxResponse = remediationOption.proceed(client, answerChallengeRequest);
 
                 // check if we landed success on login
                 if (idxResponse.isLoginSuccessful()) {
                     log.info("Login Successful!");
-                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                    TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                     log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                             tokenResponse.getAccessToken(),
                             tokenResponse.getIdToken(),
@@ -1623,18 +1615,18 @@ public class Quickstart {
                     credentials.setPasscode(NEW_PASSWORD);
 
                     // build answer password authenticator challenge request
-                    passwordAuthenticatorAnswerChallengeRequest = AnswerChallengeRequestBuilder.builder()
+                    answerChallengeRequest = AnswerChallengeRequestBuilder.builder()
                             .withStateHandle(stateHandle)
                             .withCredentials(credentials)
                             .build();
 
-                    idxResponse = remediationOption.proceed(client, passwordAuthenticatorAnswerChallengeRequest);
+                    idxResponse = remediationOption.proceed(client, answerChallengeRequest);
 
                     // check if we landed success on login
                     if (idxResponse.isLoginSuccessful()) {
                         log.info("Login Successful!");
                         // exchange the received interaction code for a token
-                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client);
+                        TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
                         log.info("Exchanged interaction code for token: \naccessToken: {}, \nidToken: {}, \nrefreshToken: {}, \ntokenType: {}, \nscope: {}, \nexpiresIn:{}",
                                 tokenResponse.getAccessToken(),
                                 tokenResponse.getIdToken(),

--- a/impl/src/test/groovy/com/okta/idx/sdk/impl/client/BaseIDXClientTest.groovy
+++ b/impl/src/test/groovy/com/okta/idx/sdk/impl/client/BaseIDXClientTest.groovy
@@ -1193,8 +1193,6 @@ class BaseIDXClientTest {
 
         RequestExecutor requestExecutor = mock(RequestExecutor)
 
-        //todo
-
         final IDXClient idxClient =
                 new BaseIDXClient(getClientConfiguration(), requestExecutor)
 

--- a/impl/src/test/groovy/com/okta/idx/sdk/impl/client/BaseIDXClientTest.groovy
+++ b/impl/src/test/groovy/com/okta/idx/sdk/impl/client/BaseIDXClientTest.groovy
@@ -27,12 +27,12 @@ import com.okta.idx.sdk.api.model.Authenticator
 import com.okta.idx.sdk.api.model.AuthenticatorEnrollment
 import com.okta.idx.sdk.api.model.Credentials
 import com.okta.idx.sdk.api.model.FormValue
+import com.okta.idx.sdk.api.model.IDXClientContext
 import com.okta.idx.sdk.api.model.Options
 import com.okta.idx.sdk.api.model.RemediationOption
 import com.okta.idx.sdk.api.model.UserProfile
 import com.okta.idx.sdk.api.request.AnswerChallengeRequest
 import com.okta.idx.sdk.api.request.AnswerChallengeRequestBuilder
-import com.okta.idx.sdk.api.request.CancelRequest
 import com.okta.idx.sdk.api.request.ChallengeRequest
 import com.okta.idx.sdk.api.request.ChallengeRequestBuilder
 import com.okta.idx.sdk.api.request.EnrollRequest
@@ -45,15 +45,13 @@ import com.okta.idx.sdk.api.request.RecoverRequest
 import com.okta.idx.sdk.api.request.RecoverRequestBuilder
 import com.okta.idx.sdk.api.request.SkipAuthenticatorEnrollmentRequest
 import com.okta.idx.sdk.api.request.SkipAuthenticatorEnrollmentRequestBuilder
-import com.okta.idx.sdk.api.response.InteractResponse
+
 import com.okta.idx.sdk.api.response.IDXResponse
 import com.okta.idx.sdk.api.response.TokenResponse
 import com.okta.idx.sdk.impl.config.ClientConfiguration
 import org.testng.annotations.Test
 
 import static org.hamcrest.Matchers.arrayWithSize
-import static org.hamcrest.Matchers.hasLength
-import static org.hamcrest.Matchers.hasSize
 import static org.hamcrest.Matchers.is
 import static org.mockito.Mockito.any
 import static org.mockito.Mockito.mock
@@ -68,7 +66,7 @@ import static org.hamcrest.Matchers.nullValue
 class BaseIDXClientTest {
 
     @Test
-    void testInteractResponse() {
+    void testIDXClientContext() {
 
         RequestExecutor requestExecutor = mock(RequestExecutor)
 
@@ -83,10 +81,12 @@ class BaseIDXClientTest {
 
         when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedResponse)
 
-        InteractResponse response = idxClient.interact()
+        IDXClientContext idxClientContext = idxClient.interact()
 
-        assertThat(response, notNullValue())
-        assertThat(response.getInteractionHandle(), is("003Q14X7li"))
+        assertThat(idxClientContext, notNullValue())
+        assertThat(idxClientContext.getCodeVerifier(), notNullValue())
+        assertThat(idxClientContext.getState(), notNullValue())
+        assertThat(idxClientContext.getInteractionHandle(), is("003Q14X7li"))
     }
 
     @Test
@@ -97,15 +97,25 @@ class BaseIDXClientTest {
         final IDXClient idxClient =
             new BaseIDXClient(getClientConfiguration(), requestExecutor)
 
-        final Response stubbedResponse = new DefaultResponse(
+        final Response stubbedInteractResponse = new DefaultResponse(
+                200,
+                MediaType.valueOf("application/json"),
+                new FileInputStream(getClass().getClassLoader().getResource("interact-response.json").getFile()),
+                -1)
+
+        when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedInteractResponse)
+
+        IDXClientContext idxClientContext = idxClient.interact()
+
+        final Response stubbedIntrospectResponse = new DefaultResponse(
             200,
             MediaType.valueOf("application/ion+json; okta-version=1.0.0"),
             new FileInputStream(getClass().getClassLoader().getResource("introspect-response.json").getFile()),
             -1)
 
-        when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedResponse)
+        when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedIntrospectResponse)
 
-        IDXResponse response = idxClient.introspect(Optional.of("interactionHandle"))
+        IDXResponse response = idxClient.introspect(idxClientContext)
 
         assertThat(response, notNullValue())
         assertThat(response.remediation(), notNullValue())
@@ -165,6 +175,16 @@ class BaseIDXClientTest {
         final IDXClient idxClient =
             new BaseIDXClient(getClientConfiguration(), requestExecutor)
 
+        final Response stubbedInteractResponse = new DefaultResponse(
+                200,
+                MediaType.valueOf("application/json"),
+                new FileInputStream(getClass().getClassLoader().getResource("interact-response.json").getFile()),
+                -1)
+
+        when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedInteractResponse)
+
+        IDXClientContext idxClientContext = idxClient.interact()
+
         final Response stubbedIntrospectResponse = new DefaultResponse(
             200,
             MediaType.valueOf("application/ion+json; okta-version=1.0.0"),
@@ -173,7 +193,7 @@ class BaseIDXClientTest {
 
         when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedIntrospectResponse)
 
-        IDXResponse introspectResponse = idxClient.introspect(Optional.of("interactionHandle"))
+        IDXResponse introspectResponse = idxClient.introspect(idxClientContext)
 
         assertThat(introspectResponse.remediation().remediationOptions(), notNullValue())
         assertThat(introspectResponse.remediation.value.first().href, equalTo("https://foo.oktapreview.com/idp/idx/identify"))
@@ -314,6 +334,16 @@ class BaseIDXClientTest {
         final IDXClient idxClient =
             new BaseIDXClient(getClientConfiguration(), requestExecutor)
 
+        final Response stubbedInteractResponse = new DefaultResponse(
+                200,
+                MediaType.valueOf("application/json"),
+                new FileInputStream(getClass().getClassLoader().getResource("interact-response.json").getFile()),
+                -1)
+
+        when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedInteractResponse)
+
+        IDXClientContext idxClientContext = idxClient.interact()
+
         final Response stubbedIntrospectResponse = new DefaultResponse(
             200,
             MediaType.valueOf("application/ion+json; okta-version=1.0.0"),
@@ -322,7 +352,7 @@ class BaseIDXClientTest {
 
         when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedIntrospectResponse)
 
-        IDXResponse introspectResponse = idxClient.introspect(Optional.of("interactionHandle"))
+        IDXResponse introspectResponse = idxClient.introspect(idxClientContext)
 
         assertThat(introspectResponse.remediation().remediationOptions(), notNullValue())
         assertThat(introspectResponse.remediation.value.first().href, equalTo("https://foo.oktapreview.com/idp/idx/identify"))
@@ -642,6 +672,8 @@ class BaseIDXClientTest {
         final IDXClient idxClient =
                 new BaseIDXClient(getClientConfiguration(), requestExecutor)
 
+        final IDXClientContext idxClientContext = new IDXClientContext("codeVerifier", "interactionHandle", "state")
+
         final Response stubbedTokenResponse = new DefaultResponse(
                 200,
                 MediaType.valueOf("application/json"),
@@ -650,7 +682,7 @@ class BaseIDXClientTest {
 
         when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedTokenResponse)
 
-        TokenResponse tokenResponse = idxClient.token("tokenUrl","grantType", "interactionCode")
+        TokenResponse tokenResponse = idxClient.token("tokenUrl","grantType", "interactionCode", idxClientContext)
 
         assertThat(tokenResponse, notNullValue())
         assertThat(tokenResponse.tokenType, is("Bearer"))
@@ -980,6 +1012,16 @@ class BaseIDXClientTest {
         final IDXClient idxClient =
                 new BaseIDXClient(getClientConfiguration(), requestExecutor)
 
+        final Response stubbedInteractResponse = new DefaultResponse(
+                200,
+                MediaType.valueOf("application/json"),
+                new FileInputStream(getClass().getClassLoader().getResource("interact-response.json").getFile()),
+                -1)
+
+        when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedInteractResponse)
+
+        IDXClientContext idxClientContext = idxClient.interact()
+
         final Response stubbedIntrospectResponse = new DefaultResponse(
                 200,
                 MediaType.valueOf("application/ion+json; okta-version=1.0.0"),
@@ -988,7 +1030,7 @@ class BaseIDXClientTest {
 
         when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedIntrospectResponse)
 
-        IDXResponse introspectResponse = idxClient.introspect(Optional.of("interactionHandle"))
+        IDXResponse introspectResponse = idxClient.introspect(idxClientContext)
 
         assertThat(introspectResponse.remediation().remediationOptions(), notNullValue())
         assertThat(introspectResponse.remediation.value.first().href, equalTo("https://foo.oktapreview.com/idp/idx/identify"))
@@ -1125,6 +1167,8 @@ class BaseIDXClientTest {
         final IDXClient idxClient =
                 new BaseIDXClient(getClientConfiguration(), requestExecutor)
 
+        final IDXClientContext idxClientContext = new IDXClientContext("codeVerifier", "expiredInteractionHandle", "state")
+
         final Response stubbedIntrospectResponse = new DefaultResponse(
                 401,
                 MediaType.valueOf("application/ion+json; okta-version=1.0.0"),
@@ -1134,7 +1178,7 @@ class BaseIDXClientTest {
         when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedIntrospectResponse)
 
         try {
-            idxClient.introspect(Optional.of("expiredInteractionHandle"))
+            idxClient.introspect(idxClientContext)
         } catch (ProcessingException e) {
             assertThat(e.getHttpStatus(), is(401))
             assertThat(e.getMessage(), is("Request to " + clientConfiguration.getBaseUrl() + "/idp/idx/introspect failed. HTTP status: 401"))
@@ -1149,8 +1193,12 @@ class BaseIDXClientTest {
 
         RequestExecutor requestExecutor = mock(RequestExecutor)
 
+        //todo
+
         final IDXClient idxClient =
                 new BaseIDXClient(getClientConfiguration(), requestExecutor)
+
+        final IDXClientContext idxClientContext = new IDXClientContext("codeVerifier", "interactionHandle", "state")
 
         final Response stubbedTokenResponse = new DefaultResponse(
                 400,
@@ -1161,7 +1209,7 @@ class BaseIDXClientTest {
         when(requestExecutor.executeRequest(any(Request.class))).thenReturn(stubbedTokenResponse)
 
         try {
-            idxClient.token("tokenUrl", "grantType", "interactionCode")
+            idxClient.token("tokenUrl", "grantType", "interactionCode", idxClientContext)
         } catch (ProcessingException e) {
             assertThat(e.getMessage(), is("Request to tokenUrl failed. HTTP status: 400"))
             assertThat(e.getHttpStatus(), is(400))

--- a/integration-tests/src/test/groovy/com/okta/idx/sdk/tests/it/EndToEndIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/idx/sdk/tests/it/EndToEndIT.groovy
@@ -26,6 +26,7 @@ import com.okta.idx.sdk.api.client.IDXClient
 import com.okta.idx.sdk.api.client.IDXClientBuilder
 import com.okta.idx.sdk.api.model.Authenticator
 import com.okta.idx.sdk.api.model.Credentials
+import com.okta.idx.sdk.api.model.IDXClientContext
 import com.okta.idx.sdk.api.model.RemediationOption
 import com.okta.idx.sdk.api.request.AnswerChallengeRequest
 import com.okta.idx.sdk.api.request.AnswerChallengeRequestBuilder
@@ -33,7 +34,7 @@ import com.okta.idx.sdk.api.request.ChallengeRequest
 import com.okta.idx.sdk.api.request.ChallengeRequestBuilder
 import com.okta.idx.sdk.api.request.IdentifyRequest
 import com.okta.idx.sdk.api.request.IdentifyRequestBuilder
-import com.okta.idx.sdk.api.response.InteractResponse
+
 import com.okta.idx.sdk.api.response.IDXResponse
 import org.testng.annotations.AfterClass
 import org.testng.annotations.BeforeClass
@@ -86,10 +87,10 @@ class EndToEndIT {
                 .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                 .withBodyFile("interact-response.json")))
 
-        InteractResponse interactResponse = idxClient.interact()
+        IDXClientContext idxClientContext = idxClient.interact()
 
-        assertThat(interactResponse, notNullValue())
-        assertThat(interactResponse.getInteractionHandle(), is("003Q14X7li"))
+        assertThat(idxClientContext, notNullValue())
+        assertThat(idxClientContext.getInteractionHandle(), is("003Q14X7li"))
 
         wireMockServer.verify(postRequestedFor(urlEqualTo("/v1/interact"))
             .withHeader("Content-Type", equalTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE)))
@@ -103,7 +104,7 @@ class EndToEndIT {
                 .withHeader("Content-Type", "application/ion+json;okta-version=1.0.0")
                 .withBodyFile("introspect-response.json")))
 
-        IDXResponse idxResponse = idxClient.introspect(Optional.of("interactionHandle"))
+        IDXResponse idxResponse = idxClient.introspect(idxClientContext)
 
         assertThat(idxResponse, notNullValue())
 
@@ -295,10 +296,10 @@ class EndToEndIT {
                 .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                 .withBodyFile("interact-response.json")))
 
-        InteractResponse interactResponse = idxClient.interact()
+        IDXClientContext idxClientContext = idxClient.interact()
 
-        assertThat(interactResponse, notNullValue())
-        assertThat(interactResponse.getInteractionHandle(), is("003Q14X7li"))
+        assertThat(idxClientContext, notNullValue())
+        assertThat(idxClientContext.getInteractionHandle(), is("003Q14X7li"))
 
         wireMockServer.verify(postRequestedFor(urlEqualTo("/v1/interact"))
             .withHeader("Content-Type", equalTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE)))
@@ -312,7 +313,7 @@ class EndToEndIT {
                 .withHeader("Content-Type", "application/ion+json;okta-version=1.0.0")
                 .withBodyFile("introspect-response.json")))
 
-        IDXResponse idxResponse = idxClient.introspect(Optional.of("interactionHandle"))
+        IDXResponse idxResponse = idxClient.introspect(idxClientContext)
 
         assertThat(idxResponse, notNullValue())
 


### PR DESCRIPTION

- Update the SDK to allow for resuming a flow from any point (OKTA-362449).
- Create an immutable object of `codeVerifier` and `interactionHandle` that can be used outside of the client.
- Move the creation of `codeVerifier` into _interact_ method.
- Use the new object in _exchangeCode_ method.
- Update all ITs and UTs.
- Update README code snippets.
