### PR TITLE
Exchange Tokens when all authenticators are enrolled.

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -29,6 +29,7 @@ This project includes:
   Okta Commons :: Config Check under The Apache License, Version 2.0
   Okta Commons :: HTTP :: API under The Apache License, Version 2.0
   Okta Commons :: Lang under The Apache License, Version 2.0
+  Okta JWT Verifier :: API under The Apache License, Version 2.0
   SLF4J API Module under MIT License
   SnakeYAML under Apache License, Version 2.0
   Spring AOP under Apache License, Version 2.0

--- a/api/src/main/java/com/okta/idx/sdk/api/response/AuthenticationResponse.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/response/AuthenticationResponse.java
@@ -23,8 +23,6 @@ import java.util.List;
 
 public class AuthenticationResponse {
 
-    private String user;
-
     private TokenResponse tokenResponse;
 
     private IDXClientContext idxClientContext;
@@ -32,14 +30,6 @@ public class AuthenticationResponse {
     private AuthenticationStatus authenticationStatus;
 
     private List<String> errors = new LinkedList<>();
-
-    public String getUser() {
-        return user;
-    }
-
-    public void setUser(String user) {
-        this.user = user;
-    }
 
     public TokenResponse getTokenResponse() {
         return tokenResponse;

--- a/api/src/main/java/com/okta/idx/sdk/api/wrapper/AuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/wrapper/AuthenticationWrapper.java
@@ -631,6 +631,14 @@ public class AuthenticationWrapper {
                     extractRemediationOption(remediationOptions, RemediationType.SELECT_AUTHENTICATOR_ENROLL);
                 }
             }
+
+            if (challengeAuthenticatorResponse.isLoginSuccessful()) {
+                // login successful
+                logger.info("Login Successful!");
+                TokenResponse tokenResponse = challengeAuthenticatorResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
+                authenticationResponse.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
+                authenticationResponse.setTokenResponse(tokenResponse);
+            }
         } catch (ProcessingException e) {
             handleProcessingException(e, authenticationResponse);
         } catch (IllegalArgumentException e) {
@@ -689,6 +697,14 @@ public class AuthenticationWrapper {
                     logger.warn("Skip authenticator not found in remediation option");
                     extractRemediationOption(remediationOptions, RemediationType.SELECT_AUTHENTICATOR_ENROLL);
                 }
+            }
+
+            if (challengeAuthenticatorResponse.isLoginSuccessful()) {
+                // login successful
+                logger.info("Login Successful!");
+                TokenResponse tokenResponse = challengeAuthenticatorResponse.getSuccessWithInteractionCode().exchangeCode(client, idxClientContext);
+                authenticationResponse.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
+                authenticationResponse.setTokenResponse(tokenResponse);
             }
         } catch (ProcessingException e) {
             handleProcessingException(e, authenticationResponse);

--- a/api/src/main/java/com/okta/idx/sdk/api/wrapper/AuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/wrapper/AuthenticationWrapper.java
@@ -82,7 +82,6 @@ public class AuthenticationWrapper {
                                                       AuthenticationOptions authenticationOptions) {
 
         AuthenticationResponse authenticationResponse = new AuthenticationResponse();
-        authenticationResponse.setUser(authenticationOptions.getUsername());
 
         TokenResponse tokenResponse;
         IDXClientContext idxClientContext = null;

--- a/direct-auth-samples/pom.xml
+++ b/direct-auth-samples/pom.xml
@@ -34,6 +34,7 @@
         <checkstyle-maven-plugin.version>3.1.2</checkstyle-maven-plugin.version>
         <java.version>1.8</java.version>
         <okta.sdk.version>0.1.0-beta.6-SNAPSHOT</okta.sdk.version>
+        <okta.jwt.version>0.5.1</okta.jwt.version>
     </properties>
 
     <dependencies>
@@ -89,6 +90,19 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Used to parse the email out of the id token -->
+        <dependency>
+            <groupId>com.okta.jwt</groupId>
+            <artifactId>okta-jwt-verifier</artifactId>
+            <version>${okta.jwt.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.okta.jwt</groupId>
+            <artifactId>okta-jwt-verifier-impl</artifactId>
+            <version>${okta.jwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/config/ApplicationConfig.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/config/ApplicationConfig.java
@@ -17,6 +17,9 @@ package com.okta.spring.example.config;
 
 import com.okta.idx.sdk.api.client.Clients;
 import com.okta.idx.sdk.api.client.IDXClient;
+import com.okta.jwt.AccessTokenVerifier;
+import com.okta.jwt.JwtVerifiers;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -31,5 +34,18 @@ public class ApplicationConfig {
     @Bean
     public IDXClient idxClient() {
         return Clients.builder().build();
+    }
+
+    /**
+     * The accessTokenVerifier bean definition.
+     *
+     * @return the accessTokenVerifier
+     */
+    @Bean
+    public AccessTokenVerifier accessTokenVerifier() {
+        return JwtVerifiers.accessTokenVerifierBuilder()
+                .setIssuer("https://{your_okta_domain}/oauth2/default")
+                .setAudience("{your_client_id}")
+                .build();
     }
 }

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/HomeController.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/HomeController.java
@@ -16,13 +16,25 @@
 package com.okta.spring.example.controllers;
 
 import com.okta.idx.sdk.api.model.AuthenticatorUIOption;
+import com.okta.idx.sdk.api.response.TokenResponse;
+import com.okta.spring.example.helpers.HomeHelper;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
 
+import javax.servlet.http.HttpSession;
+
 @Controller
 public class HomeController {
+
+    /**
+     * homeHelper instance.
+     */
+    @Autowired
+    private HomeHelper homeHelper;
 
     /**
      * Display the home page.
@@ -40,7 +52,14 @@ public class HomeController {
      * @return the login view
      */
     @GetMapping(value = "/custom-login")
-    public ModelAndView displayLoginPage() {
+    public ModelAndView displayLoginPage(final HttpSession session) {
+        TokenResponse tokenResponse =
+                (TokenResponse) session.getAttribute("tokenResponse");
+
+        // render token response if a successful one is already present in session
+        if (tokenResponse != null) {
+            return homeHelper.proceedToHome(tokenResponse, session);
+        }
         return new ModelAndView("login");
     }
 

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/HomeController.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/HomeController.java
@@ -49,6 +49,8 @@ public class HomeController {
     /**
      * Display the login page.
      *
+     * @param session
+     *
      * @return the login view
      */
     @GetMapping(value = "/custom-login")

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
@@ -18,7 +18,13 @@ public class HomeHelper {
     @Autowired
     private AccessTokenVerifier accessTokenVerifier;
 
-    public ModelAndView proceedToHome(TokenResponse tokenResponse, HttpSession session) {
+    /**
+     * Go to the home page, setting the session, and creating the view.
+     * @param tokenResponse
+     * @param session
+     * @return the ModelAndView for the home page.
+     */
+    public ModelAndView proceedToHome(final TokenResponse tokenResponse, final HttpSession session) {
         // success
         ModelAndView mav = new ModelAndView("home");
         mav.addObject("tokenResponse", tokenResponse);

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
@@ -1,0 +1,38 @@
+package com.okta.spring.example.helpers;
+
+import com.okta.idx.sdk.api.response.TokenResponse;
+import com.okta.jwt.AccessTokenVerifier;
+import com.okta.jwt.JwtVerificationException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpSession;
+
+@Component
+public class HomeHelper {
+    /**
+     * jwt parser instance.
+     */
+    @Autowired
+    private AccessTokenVerifier accessTokenVerifier;
+
+    public ModelAndView proceedToHome(TokenResponse tokenResponse, HttpSession session) {
+        // success
+        ModelAndView mav = new ModelAndView("home");
+        mav.addObject("tokenResponse", tokenResponse);
+        String user = null;
+        try {
+            user = (String) accessTokenVerifier.decode(tokenResponse.idToken).getClaims().get("email");
+        } catch (JwtVerificationException e) {
+            e.printStackTrace();
+        }
+        mav.addObject("user", user);
+
+        // store token in session
+        session.setAttribute("tokenResponse", tokenResponse);
+
+        return mav;
+    }
+}

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.spring.example.helpers;
 
 import com.okta.idx.sdk.api.response.TokenResponse;

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/package-info.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ *  This package contains helper classes for controllers.
+ */
+package com.okta.spring.example.helpers;

--- a/direct-auth-samples/src/main/resources/templates/home.html
+++ b/direct-auth-samples/src/main/resources/templates/home.html
@@ -23,50 +23,45 @@
 </head>
 <body>
 
-<div th:if="${authenticationResponse.user}">
+<div th:if="${tokenResponse}">
     <a href="/logout" class="btn btn-danger pull-right">Logout</a>
 </div>
 
 <div class="container">
 
-    <div th:if="${authenticationResponse.user}" class="alert alert-success">
-        <p>Welcome, <span th:text="${authenticationResponse.user}"></span>!</p>
+    <div th:if="${tokenResponse}" class="alert alert-success">
+        <p>Welcome, <span th:text="${user}"></span>!</p>
         <p>You have successfully authenticated against your Okta Org.</p>
     </div>
 
-    <div th:if="${authenticationResponse.tokenResponse.accessToken}">
+    <div th:if="${tokenResponse.accessToken}">
         <p><label>Access Token: </label>
-            <span th:text="${authenticationResponse.tokenResponse.accessToken}">2</span></p>
+            <span th:text="${tokenResponse.accessToken}">2</span></p>
     </div>
 
-    <div th:if="${authenticationResponse.tokenResponse.expiresIn}">
+    <div th:if="${tokenResponse.expiresIn}">
         <p><label>Expires In: </label>
-            <span th:text="${authenticationResponse.tokenResponse.expiresIn}">1</span></p>
+            <span th:text="${tokenResponse.expiresIn}">1</span></p>
     </div>
 
-    <div th:if="${authenticationResponse.tokenResponse.idToken}">
+    <div th:if="${tokenResponse.idToken}">
         <p><label>ID Token: </label>
-            <span th:text="${authenticationResponse.tokenResponse.idToken}">1</span></p>
+            <span th:text="${tokenResponse.idToken}">1</span></p>
     </div>
 
-    <div th:if="${authenticationResponse.tokenResponse.refreshToken}">
+    <div th:if="${tokenResponse.refreshToken}">
         <p><label>Refresh Token: </label>
-            <span th:text="${authenticationResponse.tokenResponse.refreshToken}">1</span></p>
+            <span th:text="${tokenResponse.refreshToken}">1</span></p>
     </div>
 
-    <div th:if="${authenticationResponse.tokenResponse.scope}">
+    <div th:if="${tokenResponse.scope}">
         <p><label>Scope(s): </label>
-            <span th:text="${authenticationResponse.tokenResponse.scope}">1</span></p>
+            <span th:text="${tokenResponse.scope}">1</span></p>
     </div>
 
-    <div th:if="${authenticationResponse.tokenResponse.tokenType}">
+    <div th:if="${tokenResponse.tokenType}">
         <p><label>Token Type: </label>
-            <span th:text="${authenticationResponse.tokenResponse.tokenType}">1</span></p>
-    </div>
-
-    <div th:if="${authenticationResponse.errors}">
-        <p><label>Errors: </label>
-            <span th:text="${authenticationResponse.errors}">1</span></p>
+            <span th:text="${tokenResponse.tokenType}">1</span></p>
     </div>
 </div>
 


### PR DESCRIPTION
Before this change, the response wouldn't contain tokens after enrolling the last authenticator.

Now once you've gone through a complete enrollment, the response will contain tokens you can use to act as a logged in user.