### PR TITLE
OKTA-388348 - fix interact uri for org AS

### DIFF
--- a/impl/src/main/java/com/okta/idx/sdk/impl/client/BaseIDXClient.java
+++ b/impl/src/main/java/com/okta/idx/sdk/impl/client/BaseIDXClient.java
@@ -112,8 +112,9 @@ public class BaseIDXClient implements IDXClient {
 
             Request request = new DefaultRequest(
                 HttpMethod.POST,
-                    isRootOrgIssuer(clientConfiguration.getIssuer()) ? clientConfiguration.getIssuer() + "/oauth2/v1/interact" :
-                    clientConfiguration.getIssuer() + "/v1/interact",
+                    isRootOrgIssuer(clientConfiguration.getIssuer()) ?
+                            clientConfiguration.getIssuer() + "/oauth2/v1/interact" :
+                            clientConfiguration.getIssuer() + "/v1/interact",
                 null,
                 getHttpHeaders(true),
                 new ByteArrayInputStream(urlParameters.toString().getBytes(StandardCharsets.UTF_8)),

--- a/impl/src/main/java/com/okta/idx/sdk/impl/client/BaseIDXClient.java
+++ b/impl/src/main/java/com/okta/idx/sdk/impl/client/BaseIDXClient.java
@@ -51,22 +51,16 @@ import com.okta.idx.sdk.api.response.IDXResponse;
 import com.okta.idx.sdk.api.response.InteractResponse;
 import com.okta.idx.sdk.api.response.TokenResponse;
 import com.okta.idx.sdk.impl.config.ClientConfiguration;
+import static com.okta.idx.sdk.impl.util.ClientUtil.isRootOrgIssuer;
 import com.okta.idx.sdk.impl.util.PkceUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class BaseIDXClient implements IDXClient {
-
-    private static final Logger logger = LoggerFactory.getLogger(BaseIDXClient.class);
 
     private static final String USER_AGENT_HEADER_VALUE = "okta-idx-java/1.0.0";
 
@@ -118,7 +112,7 @@ public class BaseIDXClient implements IDXClient {
 
             Request request = new DefaultRequest(
                 HttpMethod.POST,
-                isRootOrgIssuer(clientConfiguration.getIssuer()) ? clientConfiguration.getIssuer() + "/oauth2/v1/interact" :
+                    isRootOrgIssuer(clientConfiguration.getIssuer()) ? clientConfiguration.getIssuer() + "/oauth2/v1/interact" :
                     clientConfiguration.getIssuer() + "/v1/interact",
                 null,
                 getHttpHeaders(true),
@@ -527,36 +521,5 @@ public class BaseIDXClient implements IDXClient {
 
         httpHeaders.add(HttpHeaders.USER_AGENT, USER_AGENT_HEADER_VALUE);
         return httpHeaders;
-    }
-
-    /**
-     * Check if the issuer is root/org URI.
-     *
-     * Issuer URL that does not follow the pattern '/oauth2/default' (or) '/oauth2/some_id_string' is
-     * considered root/org issuer.
-     *
-     * e.g. https://sample.okta.com (root/org url)
-     *      https://sample.okta.com/oauth2/default (non-root issuer/org url)
-     *      https://sample.okta.com/oauth2/ausar5cbq5TRRsbcJ0h7 (non-root issuer/org url)
-     *
-     * @param issuerUri
-     * @return true if root/org, false otherwise
-     */
-    private boolean isRootOrgIssuer(String issuerUri) throws MalformedURLException {
-        String uriPath = new URL(issuerUri).getPath();
-
-        if (Strings.hasText(uriPath)) {
-            String[] tokenizedUri = uriPath.substring(uriPath.indexOf("/")+1).split("/");
-
-            if (tokenizedUri.length >= 2 &&
-                    "oauth2".equals(tokenizedUri[0]) &&
-                    Strings.hasText(tokenizedUri[1])) {
-                logger.debug("The issuer URL: '{}' is an Okta custom authorization server", issuerUri);
-                return false;
-            }
-        }
-
-        logger.debug("The issuer URL: '{}' is an Okta root/org authorization server", issuerUri);
-        return true;
     }
 }

--- a/impl/src/main/java/com/okta/idx/sdk/impl/util/ClientUtil.java
+++ b/impl/src/main/java/com/okta/idx/sdk/impl/util/ClientUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.idx.sdk.impl.util;
 
 import com.okta.commons.lang.Strings;

--- a/impl/src/main/java/com/okta/idx/sdk/impl/util/ClientUtil.java
+++ b/impl/src/main/java/com/okta/idx/sdk/impl/util/ClientUtil.java
@@ -1,0 +1,44 @@
+package com.okta.idx.sdk.impl.util;
+
+import com.okta.commons.lang.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class ClientUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClientUtil.class);
+
+    /**
+     * Check if the issuer is root/org URI.
+     *
+     * Issuer URL that does not follow the pattern '/oauth2/default' (or) '/oauth2/some_id_string' is
+     * considered root/org issuer.
+     *
+     * e.g. https://sample.okta.com (root/org url)
+     *      https://sample.okta.com/oauth2/default (non-root issuer/org url)
+     *      https://sample.okta.com/oauth2/ausar5cbq5TRRsbcJ0h7 (non-root issuer/org url)
+     *
+     * @param issuerUri
+     * @return true if root/org, false otherwise
+     */
+    public static boolean isRootOrgIssuer(String issuerUri) throws MalformedURLException {
+        String uriPath = new URL(issuerUri).getPath();
+
+        if (Strings.hasText(uriPath)) {
+            String[] tokenizedUri = uriPath.substring(uriPath.indexOf("/")+1).split("/");
+
+            if (tokenizedUri.length >= 2 &&
+                    "oauth2".equals(tokenizedUri[0]) &&
+                    Strings.hasText(tokenizedUri[1])) {
+                logger.debug("The issuer URL: '{}' is an Okta custom authorization server", issuerUri);
+                return false;
+            }
+        }
+
+        logger.debug("The issuer URL: '{}' is an Okta root/org authorization server", issuerUri);
+        return true;
+    }
+}

--- a/impl/src/test/groovy/com/okta/idx/sdk/impl/client/BaseIDXClientTest.groovy
+++ b/impl/src/test/groovy/com/okta/idx/sdk/impl/client/BaseIDXClientTest.groovy
@@ -51,6 +51,7 @@ import com.okta.idx.sdk.api.response.TokenResponse
 import com.okta.idx.sdk.impl.config.ClientConfiguration
 import org.testng.annotations.Test
 
+import static com.okta.idx.sdk.impl.util.ClientUtil.isRootOrgIssuer
 import static org.hamcrest.Matchers.arrayWithSize
 import static org.hamcrest.Matchers.is
 import static org.mockito.Mockito.any
@@ -1152,8 +1153,10 @@ class BaseIDXClientTest {
         try {
             idxClient.interact()
         } catch (ProcessingException e) {
+            String interactUrl = isRootOrgIssuer(clientConfiguration.getIssuer()) ? clientConfiguration.getIssuer() + "/oauth2/v1/interact" :
+                    clientConfiguration.getIssuer() + "/v1/interact";
             assertThat(e.getHttpStatus(), is(400))
-            assertThat(e.getMessage(), is("Request to " + clientConfiguration.getIssuer() + "/v1/interact failed. HTTP status: 400"))
+            assertThat(e.getMessage(), is("Request to " + interactUrl + " failed. HTTP status: 400"))
             assertThat(e.getErrorResponse(), notNullValue())
             assertThat(e.getErrorResponse().getError(), is("invalid_request"))
             assertThat(e.getErrorResponse().getErrorDescription(), is("PKCE code challenge is required when the token endpoint authentication method is 'NONE'."))
@@ -1239,8 +1242,10 @@ class BaseIDXClientTest {
         try {
             idxClient.interact()
         } catch (ProcessingException e) {
+            String interactUrl = isRootOrgIssuer(clientConfiguration.getIssuer()) ? clientConfiguration.getIssuer() + "/oauth2/v1/interact" :
+                    clientConfiguration.getIssuer() + "/v1/interact";
             assertThat(e.getHttpStatus(), is(500))
-            assertThat(e.getMessage(), is("Request to " + clientConfiguration.getBaseUrl() + "/v1/interact failed. HTTP status: 500"))
+            assertThat(e.getMessage(), is("Request to " + interactUrl + " failed. HTTP status: 500"))
         }
     }
 

--- a/impl/src/test/groovy/com/okta/idx/sdk/impl/util/TestClientUtil.groovy
+++ b/impl/src/test/groovy/com/okta/idx/sdk/impl/util/TestClientUtil.groovy
@@ -29,6 +29,10 @@ class TestClientUtil {
                 ClientUtil.isRootOrgIssuer("https://dev-12345.oktapreview.com/")
         assertThat "issuer uri expected to be root/org)",
                 ClientUtil.isRootOrgIssuer("https://example.io")
+        assertThat "issuer uri expected to be root/org)",
+                ClientUtil.isRootOrgIssuer("https://example.io/")
+        assertThat "issuer uri expected to be root/org)",
+                ClientUtil.isRootOrgIssuer("https://example.io//")
     }
 
     @Test

--- a/impl/src/test/groovy/com/okta/idx/sdk/impl/util/TestClientUtil.groovy
+++ b/impl/src/test/groovy/com/okta/idx/sdk/impl/util/TestClientUtil.groovy
@@ -1,0 +1,27 @@
+package com.okta.idx.sdk.impl.util
+
+
+import org.testng.annotations.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+
+class TestClientUtil {
+
+    @Test
+    void issuerUri_rootOrgTest() {
+        assertThat "issuer uri expected to be root/org)",
+                ClientUtil.isRootOrgIssuer("https://sample.okta.com")
+        assertThat "issuer uri expected to be root/org)",
+                ClientUtil.isRootOrgIssuer("https://dev-12345.oktapreview.com/")
+        assertThat "issuer uri expected to be root/org)",
+                ClientUtil.isRootOrgIssuer("https://example.io")
+    }
+
+    @Test
+    void issuerUri_nonRootOrgTest() {
+        assertThat "issuer uri expected to be non-root/org)",
+                !ClientUtil.isRootOrgIssuer("https://sample.okta.com/oauth2/default")
+        assertThat "issuer uri expected to be non-root/org)",
+                !ClientUtil.isRootOrgIssuer("https://example.io/oauth2/ausvd5ple5TRRsbcJ0h7")
+    }
+}

--- a/impl/src/test/groovy/com/okta/idx/sdk/impl/util/TestClientUtil.groovy
+++ b/impl/src/test/groovy/com/okta/idx/sdk/impl/util/TestClientUtil.groovy
@@ -1,5 +1,19 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.idx.sdk.impl.util
-
 
 import org.testng.annotations.Test
 

--- a/integration-tests/src/test/groovy/com/okta/idx/sdk/tests/it/EndToEndIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/idx/sdk/tests/it/EndToEndIT.groovy
@@ -80,7 +80,7 @@ class EndToEndIT {
     void testWithPasswordAndEmailAuthenticators() {
 
         // interact
-        wireMockServer.stubFor(post(urlPathEqualTo("/v1/interact"))
+        wireMockServer.stubFor(post(urlPathEqualTo("/oauth2/v1/interact"))
             .withHeader("Content-Type", containing(MediaType.APPLICATION_FORM_URLENCODED_VALUE))
             .willReturn(aResponse()
                 .withStatus(HttpStatus.SC_OK)
@@ -92,7 +92,7 @@ class EndToEndIT {
         assertThat(idxClientContext, notNullValue())
         assertThat(idxClientContext.getInteractionHandle(), is("003Q14X7li"))
 
-        wireMockServer.verify(postRequestedFor(urlEqualTo("/v1/interact"))
+        wireMockServer.verify(postRequestedFor(urlEqualTo("/oauth2/v1/interact"))
             .withHeader("Content-Type", equalTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE)))
         wireMockServer.resetAll()
 
@@ -289,7 +289,7 @@ class EndToEndIT {
     void testWithSecurityQnAndEmailAuthenticators() {
 
         // interact
-        wireMockServer.stubFor(post(urlPathEqualTo("/v1/interact"))
+        wireMockServer.stubFor(post(urlPathEqualTo("/oauth2/v1/interact"))
             .withHeader("Content-Type", containing(MediaType.APPLICATION_FORM_URLENCODED_VALUE))
             .willReturn(aResponse()
                 .withStatus(HttpStatus.SC_OK)
@@ -301,7 +301,7 @@ class EndToEndIT {
         assertThat(idxClientContext, notNullValue())
         assertThat(idxClientContext.getInteractionHandle(), is("003Q14X7li"))
 
-        wireMockServer.verify(postRequestedFor(urlEqualTo("/v1/interact"))
+        wireMockServer.verify(postRequestedFor(urlEqualTo("/oauth2/v1/interact"))
             .withHeader("Content-Type", equalTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE)))
         wireMockServer.resetAll()
 


### PR DESCRIPTION
**What's done?**

`interact` endpoint is constructed like below:

**Case-1: Root/Org Issuer**

client supplied issuer - `https://{yourOktaDomain}`
constructed interact URL - `https://{yourOktaDomain}/oauth2/v1/interact`

**Case-2: Default Issuer**

client supplied issuer - `https://{yourOktaDomain}/oauth2/default`
constructed interact URL - `https://{yourOktaDomain}/oauth2/default/v1/interact`

**Variation of Case-1 with a trailing `/`**

client supplied issuer - `https://{yourOktaDomain}/`
constructed interact URL - `https://{yourOktaDomain}/oauth2/v1/interact`

 