### PR TITLE
Fixes failure in the case of any factor login app rule

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
@@ -358,6 +358,28 @@ public class IDXAuthenticationWrapper {
                 remediationOptions = identifyResponse.remediation().remediationOptions();
                 printRemediationOptions(remediationOptions);
 
+                // Check if instead of password, user is being prompted for list of authenticators to select
+                if (identifyResponse.getCurrentAuthenticatorEnrollment() == null) {
+                    remediationOption = extractRemediationOption(remediationOptions, RemediationType.SELECT_AUTHENTICATOR_AUTHENTICATE);
+
+                    Map<String, String> authenticatorOptions = remediationOption.getAuthenticatorOptions();
+
+                    Authenticator authenticator = new Authenticator();
+
+                    authenticator.setId(authenticatorOptions.get("password"));
+
+                    ChallengeRequest selectAuthenticatorRequest = ChallengeRequestBuilder.builder()
+                            .withStateHandle(introspectResponse.getStateHandle())
+                            .withAuthenticator(authenticator)
+                            .build();
+
+                    identifyResponse =
+                            remediationOption.proceed(client, selectAuthenticatorRequest);
+
+                    remediationOptions = identifyResponse.remediation().remediationOptions();
+                    printRemediationOptions(remediationOptions);
+                }
+
                 if (identifyResponse.getCurrentAuthenticatorEnrollment() == null ||
                     identifyResponse.getCurrentAuthenticatorEnrollment().getValue() == null ||
                     identifyResponse.getCurrentAuthenticatorEnrollment().getValue().getRecover() == null) {
@@ -452,14 +474,16 @@ public class IDXAuthenticationWrapper {
                     .withStateHandle(introspectResponse.getStateHandle())
                     .build();
 
-            IDXResponse recoverResponse = introspectResponse.getCurrentAuthenticatorEnrollment().getValue().getRecover()
-                    .proceed(client, recoverRequest);
+            if (introspectResponse.getCurrentAuthenticatorEnrollment() != null) {
+                IDXResponse recoverResponse = introspectResponse.getCurrentAuthenticatorEnrollment().getValue().getRecover()
+                        .proceed(client, recoverRequest);
+                remediationOptions = recoverResponse.remediation().remediationOptions();
+            }
 
-            RemediationOption[] recoverResponseRemediationOptions = recoverResponse.remediation().remediationOptions();
-            extractRemediationOption(recoverResponseRemediationOptions, RemediationType.SELECT_AUTHENTICATOR_AUTHENTICATE);
+            extractRemediationOption(remediationOptions, RemediationType.SELECT_AUTHENTICATOR_AUTHENTICATE);
 
             RemediationOption remediationOption =
-                    extractRemediationOption(recoverResponseRemediationOptions, RemediationType.SELECT_AUTHENTICATOR_AUTHENTICATE);
+                    extractRemediationOption(remediationOptions, RemediationType.SELECT_AUTHENTICATOR_AUTHENTICATE);
 
             Map<String, String> authenticatorOptions = remediationOption.getAuthenticatorOptions();
 

--- a/direct-auth-samples/src/main/resources/templates/forgot-password-authenticators.html
+++ b/direct-auth-samples/src/main/resources/templates/forgot-password-authenticators.html
@@ -55,7 +55,7 @@
         </div>
         <tr th:each="item : ${authenticatorUIOptionList}">
             <div class="form-check">
-                <input class="form-check-input" type="radio" name="authenticator-type" th:value="${item.type}">
+                <input class="form-check-input" type="radio" name="authenticator-type" th:value="${item.type}" checked="true">
                 <label class="form-check-label" th:text="${item.type}"></label>
             </div>
         </tr>


### PR DESCRIPTION
- If app sign-on rule is set for "any 1 factor" instead of "password", we will have to handle the `select-authenticator-authenticate` remediation from `identify` request
- Also adds a small fix where at least 1 authenticator radio button for recover password screen  is checked by default. This fixes the issue where user can click "Proceed" without selecting an authenticator, causing a servlet exception.