### PR TITLE
Fix skip authenticator.

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -29,6 +29,7 @@ This project includes:
   Okta Commons :: Config Check under The Apache License, Version 2.0
   Okta Commons :: HTTP :: API under The Apache License, Version 2.0
   Okta Commons :: Lang under The Apache License, Version 2.0
+  Okta IDX Java SDK :: Impl under The Apache License, Version 2.0
   Okta JWT Verifier :: API under The Apache License, Version 2.0
   SLF4J API Module under MIT License
   SnakeYAML under Apache License, Version 2.0

--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
@@ -864,8 +864,10 @@ public class IDXAuthenticationWrapper {
                             .withStateHandle(stateHandle)
                             .build();
 
-            remediationOption.proceed(client, skipAuthenticatorEnrollmentRequest);
-
+            IDXResponse skipResponse = remediationOption.proceed(client, skipAuthenticatorEnrollmentRequest);
+            Arrays.stream(skipResponse.getMessages().getValue())
+                    .forEach(msg -> authenticationResponse.addError(msg.getMessage()));
+            authenticationResponse.setAuthenticationStatus(AuthenticationStatus.SKIP_COMPLETE);
         } catch (ProcessingException e) {
             handleProcessingException(e, authenticationResponse);
         } catch (IllegalArgumentException e) {

--- a/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationStatus.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationStatus.java
@@ -19,6 +19,8 @@ public enum AuthenticationStatus {
 
     SUCCESS("success"),
 
+    SKIP_COMPLETE("skip_complete"),
+
     PASSWORD_EXPIRED("password_expired"),
 
     AWAITING_AUTHENTICATOR_SELECTION("awaiting_authenticator_selection"),

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/LoginController.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/LoginController.java
@@ -333,6 +333,12 @@ public class LoginController {
                     idxAuthenticationWrapper.skipAuthenticatorEnrollment(idxClientContext);
             if (response.getTokenResponse() != null) {
                 return homeHelper.proceedToHome(response.getTokenResponse(), session);
+            } else if (response.getAuthenticationStatus() == AuthenticationStatus.SKIP_COMPLETE) {
+                ModelAndView mav = new ModelAndView("login");
+                if (response.getErrors().size() == 1) {
+                    mav.addObject("info", response.getErrors().get(0));
+                }
+                return mav;
             }
         }
 
@@ -383,6 +389,12 @@ public class LoginController {
 
             if (response.getTokenResponse() != null) {
                 return homeHelper.proceedToHome(response.getTokenResponse(), session);
+            } else if (response.getAuthenticationStatus() == AuthenticationStatus.SKIP_COMPLETE) {
+                ModelAndView mav = new ModelAndView("login");
+                if (response.getErrors().size() == 1) {
+                    mav.addObject("info", response.getErrors().get(0));
+                }
+                return mav;
             }
         }
 


### PR DESCRIPTION
Once skip is complete, we don't have tokens, so we can't log them in under certain circumstances. 
In this case, we just redirect them to the login page and show the message from the server.

"To finish signing in, check your email."