### PR TITLE
Present forgot password errors to the user

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
@@ -323,34 +323,33 @@ public class IDXAuthenticationWrapper {
 
         List<AuthenticatorUIOption> authenticatorUIOptionList = new LinkedList<>();
 
-        try {
-            AuthenticationTransaction introspectTransaction = 
-              AuthenticationTransaction.introspect(client, idxClientContext);
+        AuthenticationTransaction introspectTransaction =
+                AuthenticationTransaction.introspect(client, idxClientContext);
 
-            Recover recover = introspectTransaction.getResponse().getCurrentAuthenticatorEnrollment().getValue().getRecover();
-          
-            AuthenticationTransaction recoverTransaction = introspectTransaction.proceed(() -> {
-                // recover password
-                RecoverRequest recoverRequest = RecoverRequestBuilder.builder()
-                        .withStateHandle(introspectTransaction.getStateHandle())
-                        .build();
-                return recover .proceed(client, recoverRequest);
-            });
+        Recover recover = introspectTransaction.getResponse().getCurrentAuthenticatorEnrollment().getValue().getRecover();
 
-            RemediationOption remediationOption =
-                    recoverTransaction.getRemediationOption(RemediationType.SELECT_AUTHENTICATOR_AUTHENTICATE);
+        AuthenticationTransaction recoverTransaction = introspectTransaction.proceed(() -> {
+            // recover password
+            RecoverRequest recoverRequest = RecoverRequestBuilder.builder()
+                    .withStateHandle(introspectTransaction.getStateHandle())
+                    .build();
+            return recover.proceed(client, recoverRequest);
+        });
 
-            Map<String, String> authenticatorOptions = remediationOption.getAuthenticatorOptions();
+        RemediationOption remediationOption =
+                recoverTransaction.getRemediationOption(RemediationType.SELECT_AUTHENTICATOR_AUTHENTICATE);
 
-            for (Map.Entry<String, String> entry : authenticatorOptions.entrySet()) {
-                if (!entry.getKey().equals(AuthenticatorType.PASSWORD.getValue()) &&
-                        !entry.getKey().equals(AuthenticatorType.EMAIL.getValue()) &&
-                        !entry.getKey().equals(AuthenticatorType.SMS.getValue())) {
-                    logger.info("Skipping unsupported authenticator - {}", entry.getKey());
-                    continue;
-                }
-                authenticatorUIOptionList.add(new AuthenticatorUIOption(entry.getValue(), entry.getKey()));
+        Map<String, String> authenticatorOptions = remediationOption.getAuthenticatorOptions();
+
+        for (Map.Entry<String, String> entry : authenticatorOptions.entrySet()) {
+            if (!entry.getKey().equals(AuthenticatorType.PASSWORD.getValue()) &&
+                    !entry.getKey().equals(AuthenticatorType.EMAIL.getValue()) &&
+                    !entry.getKey().equals(AuthenticatorType.SMS.getValue())) {
+                logger.info("Skipping unsupported authenticator - {}", entry.getKey());
+                continue;
             }
+            authenticatorUIOptionList.add(new AuthenticatorUIOption(entry.getValue(), entry.getKey()));
+        }
 
         return authenticatorUIOptionList;
     }

--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
@@ -369,11 +369,10 @@ public class IDXAuthenticationWrapper {
      * @return the list of AuthenticatorUIOptions
      */
     public List<AuthenticatorUIOption> populateForgotPasswordAuthenticatorUIOptions(
-            IDXClientContext idxClientContext) {
+            IDXClientContext idxClientContext) throws ProcessingException {
 
         List<AuthenticatorUIOption> authenticatorUIOptionList = new LinkedList<>();
 
-        try {
             IDXResponse introspectResponse = client.introspect(idxClientContext);
 
             RemediationOption[] remediationOptions = introspectResponse.remediation().remediationOptions();
@@ -404,9 +403,6 @@ public class IDXAuthenticationWrapper {
                 }
                 authenticatorUIOptionList.add(new AuthenticatorUIOption(entry.getValue(), entry.getKey()));
             }
-        } catch (ProcessingException e) {
-            logger.error("Error occurred:", e);
-        }
 
         return authenticatorUIOptionList;
     }
@@ -985,8 +981,8 @@ public class IDXAuthenticationWrapper {
      * @param e the {@link ProcessingException} reference
      * @param authenticationResponse the {@link AuthenticationResponse} reference
      */
-    private void handleProcessingException(ProcessingException e,
-                                           AuthenticationResponse authenticationResponse) {
+    public void handleProcessingException(ProcessingException e,
+                                          AuthenticationResponse authenticationResponse) {
         logger.error("Exception occurred", e);
         ErrorResponse errorResponse = e.getErrorResponse();
         if (errorResponse != null) {

--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
@@ -56,7 +56,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -768,14 +767,15 @@ public class IDXAuthenticationWrapper {
      * @param idxClientContext      the IDX Client context
      * @return the list of {@link AuthenticatorUIOption} options
      */
-    public List<AuthenticatorUIOption> populateAuthenticatorUIOptions(IDXClientContext idxClientContext) {
+    public AuthenticatorUIOptions populateAuthenticatorUIOptions(IDXClientContext idxClientContext) {
 
+        AuthenticatorUIOptions authenticatorUIOptions = new AuthenticatorUIOptions();
         List<AuthenticatorUIOption> authenticatorUIOptionList = new ArrayList<>();
 
         try {
             AuthenticationTransaction introspectTransaction = AuthenticationTransaction.introspect(client, idxClientContext);
             if (introspectTransaction.getResponse().remediation() == null) {
-                return authenticatorUIOptionList;
+                return authenticatorUIOptions;
             }
 
             RemediationOption remediationOption = null;
@@ -791,7 +791,7 @@ public class IDXAuthenticationWrapper {
             }
 
             if (remediationOption == null) {
-                return new ArrayList<>();
+                return authenticatorUIOptions;
             }
 
             Map<String, String> authenticatorOptions = remediationOption.getAuthenticatorOptions();
@@ -799,11 +799,13 @@ public class IDXAuthenticationWrapper {
             for (Map.Entry<String, String> entry : authenticatorOptions.entrySet()) {
                 authenticatorUIOptionList.add(new AuthenticatorUIOption(entry.getValue(), entry.getKey()));
             }
-        } catch (Exception e) {
+        } catch (ProcessingException e) {
             logger.error("Error occurred:", e);
+            authenticatorUIOptions.setErrors(fillProcessingErrors(e));
         }
 
-        return authenticatorUIOptionList;
+        authenticatorUIOptions.setOptions(authenticatorUIOptionList);
+        return authenticatorUIOptions;
     }
 
     /**

--- a/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticatorUIOptions.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticatorUIOptions.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.idx.sdk.api.model;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class AuthenticatorUIOptions {
+
+    private List<String> errors = new LinkedList<>();
+
+    private List<AuthenticatorUIOption> options;
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public List<AuthenticatorUIOption> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<AuthenticatorUIOption> options) {
+        this.options = options;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+
+    public boolean hasErrors() {
+        return errors.size() > 0;
+    }
+}

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/LoginController.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/LoginController.java
@@ -20,7 +20,6 @@ import com.okta.idx.sdk.api.client.IDXAuthenticationWrapper;
 import com.okta.idx.sdk.api.model.AuthenticationOptions;
 import com.okta.idx.sdk.api.model.AuthenticationStatus;
 import com.okta.idx.sdk.api.model.AuthenticatorType;
-import com.okta.idx.sdk.api.model.AuthenticatorUIOption;
 import com.okta.idx.sdk.api.model.AuthenticatorUIOptions;
 import com.okta.idx.sdk.api.model.ChangePasswordOptions;
 import com.okta.idx.sdk.api.model.IDXClientContext;
@@ -39,7 +38,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpSession;
-import java.util.List;
 
 @Controller
 public class LoginController {
@@ -85,9 +83,9 @@ public class LoginController {
         if (authenticationResponse.getAuthenticationStatus() == AuthenticationStatus.AWAITING_AUTHENTICATOR_SELECTION) {
             session.setAttribute("idxClientContext", authenticationResponse.getIdxClientContext());
             ModelAndView mav = new ModelAndView("select-authenticators");
-            List<AuthenticatorUIOption> authenticatorUIOptions =
+            AuthenticatorUIOptions authenticatorUIOptions =
                     idxAuthenticationWrapper.populateAuthenticatorUIOptions(authenticationResponse.getIdxClientContext());
-            mav.addObject("authenticatorUIOptionList", authenticatorUIOptions);
+            mav.addObject("authenticatorUIOptionList", authenticatorUIOptions.getOptions());
             return mav;
         }
 
@@ -355,10 +353,10 @@ public class LoginController {
             return homeHelper.proceedToHome(authenticationResponse.getTokenResponse(), session);
         }
 
-        List<AuthenticatorUIOption> authenticatorUIOptionList =
+        AuthenticatorUIOptions authenticatorUIOptions =
                 idxAuthenticationWrapper.populateAuthenticatorUIOptions(idxClientContext);
 
-        mav.addObject("authenticatorUIOptionList", authenticatorUIOptionList);
+        mav.addObject("authenticatorUIOptionList", authenticatorUIOptions.getOptions());
 
         session.setAttribute("idxClientContext", authenticationResponse.getIdxClientContext());
         return mav;
@@ -457,10 +455,10 @@ public class LoginController {
 
         ModelAndView mav = new ModelAndView("enroll-authenticators");
 
-        List<AuthenticatorUIOption> authenticatorUIOptionList =
+        AuthenticatorUIOptions authenticatorUIOptions =
                 idxAuthenticationWrapper.populateAuthenticatorUIOptions(idxClientContext);
 
-        mav.addObject("authenticatorUIOptionList", authenticatorUIOptionList);
+        mav.addObject("authenticatorUIOptionList", authenticatorUIOptions.getOptions());
         session.setAttribute("idxClientContext", idxClientContext);
         return mav;
     }
@@ -513,17 +511,17 @@ public class LoginController {
             }
         }
 
-        List<AuthenticatorUIOption> authenticatorUIOptionList =
+        AuthenticatorUIOptions authenticatorUIOptions =
                 idxAuthenticationWrapper.populateAuthenticatorUIOptions(idxClientContext);
 
-        if (authenticatorUIOptionList == null || authenticatorUIOptionList.size() == 0) {
+        if (authenticatorUIOptions.getOptions().size() == 0) {
             ModelAndView mav = new ModelAndView("login");
             mav.addObject("info", "Success");
             return mav;
         }
 
         ModelAndView mav = new ModelAndView("enroll-authenticators");
-        mav.addObject("authenticatorUIOptionList", authenticatorUIOptionList);
+        mav.addObject("authenticatorUIOptionList", authenticatorUIOptions.getOptions());
         session.setAttribute("idxClientContext", idxClientContext);
         return mav;
     }
@@ -628,10 +626,10 @@ public class LoginController {
 
         ModelAndView mav = new ModelAndView("enroll-authenticators");
 
-        List<AuthenticatorUIOption> authenticatorUIOptionList =
+        AuthenticatorUIOptions authenticatorUIOptions =
                 idxAuthenticationWrapper.populateAuthenticatorUIOptions(idxClientContext);
 
-        mav.addObject("authenticatorUIOptionList", authenticatorUIOptionList);
+        mav.addObject("authenticatorUIOptionList", authenticatorUIOptions.getOptions());
         session.setAttribute("idxClientContext", idxClientContext);
         return mav;
     }

--- a/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/LoginController.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/controllers/LoginController.java
@@ -17,11 +17,11 @@ package com.okta.spring.example.controllers;
 
 import com.okta.commons.lang.Strings;
 import com.okta.idx.sdk.api.client.IDXAuthenticationWrapper;
-import com.okta.idx.sdk.api.exception.ProcessingException;
 import com.okta.idx.sdk.api.model.AuthenticationOptions;
 import com.okta.idx.sdk.api.model.AuthenticationStatus;
 import com.okta.idx.sdk.api.model.AuthenticatorType;
 import com.okta.idx.sdk.api.model.AuthenticatorUIOption;
+import com.okta.idx.sdk.api.model.AuthenticatorUIOptions;
 import com.okta.idx.sdk.api.model.ChangePasswordOptions;
 import com.okta.idx.sdk.api.model.IDXClientContext;
 import com.okta.idx.sdk.api.model.UserProfile;
@@ -130,17 +130,15 @@ public class LoginController {
         switch (authenticationResponse.getAuthenticationStatus()) {
             case AWAITING_AUTHENTICATOR_SELECTION:
                 mav = new ModelAndView("forgot-password-authenticators");
-                List<AuthenticatorUIOption> uiOptions;
-                try {
-                    uiOptions = idxAuthenticationWrapper.populateForgotPasswordAuthenticatorUIOptions(
+                AuthenticatorUIOptions authenticatorUIOptions =
+                        idxAuthenticationWrapper.populateForgotPasswordAuthenticatorUIOptions(
                             authenticationResponse.getIdxClientContext());
-                } catch (ProcessingException e) {
-                    idxAuthenticationWrapper.handleProcessingException(e, authenticationResponse);
+                if (authenticatorUIOptions.hasErrors()) {
                     mav = new ModelAndView("login");
-                    mav.addObject("errors", authenticationResponse.getErrors());
+                    mav.addObject("errors", authenticatorUIOptions.getErrors());
                     return mav;
                 }
-                mav.addObject("authenticatorUIOptionList", uiOptions);
+                mav.addObject("authenticatorUIOptionList", authenticatorUIOptions.getOptions());
                 return mav;
 
             case AWAITING_USER_EMAIL_ACTIVATION:


### PR DESCRIPTION
After this change, we would be able to propagate the below backend error to the UI for Forgot password case.

Backend error:

```
2021-05-02 22:35:46.681 ERROR 26698 --- [nio-8080-exec-8] c.o.i.s.a.c.IDXAuthenticationWrapper     : Exception occurred

com.okta.idx.sdk.api.exception.ProcessingException: Request to https://dev-30426356.okta.com/idp/idx/recover failed. HTTP status: 400
        at com.okta.idx.sdk.api.client.BaseIDXClient.handleErrorResponse(BaseIDXClient.java:505) ~[okta-idx-java-api-0.1.0-beta.6-SNAPSHOT.jar:0.1.0-beta.6-SNAPSHOT]
        at com.okta.idx.sdk.api.client.BaseIDXClient.recover(BaseIDXClient.java:413) ~[okta-idx-java-api-0.1.0-beta.6-SNAPSHOT.jar:0.1.0-beta.6-SNAPSHOT]
        at com.okta.idx.sdk.api.model.Recover.proceed(Recover.java:72) ~[okta-idx-java-api-0.1.0-beta.6-SNAPSHOT.jar:0.1.0-beta.6-SNAPSHOT]
        at com.okta.idx.sdk.api.client.IDXAuthenticationWrapper.populateForgotPasswordAuthenticatorUIOptions(IDXAuthenticationWrapper.java:387) ~[okta-idx-java-api-0.1.0-beta.6-SNAPSHOT.jar:0.1.0-beta.6-SNAPSHOT]
        at com.okta.spring.example.controllers.LoginController.handleForgotPassword(LoginController.java:135) ~[classes/:na]

2021-05-02 22:35:46.693 ERROR 26698 --- [nio-8080-exec-8] c.o.i.s.a.c.IDXAuthenticationWrapper     : Error Detail: [Reset password is not allowed at this time. Please contact support for assistance.]

```

<img width="633" alt="image" src="https://user-images.githubusercontent.com/61501885/116844186-39056b80-ab97-11eb-840f-7382be4209e5.png">

<img width="632" alt="image" src="https://user-images.githubusercontent.com/61501885/116844199-41f63d00-ab97-11eb-88b7-098e7d69ecf9.png">
