### PR TITLE
Return authenticators on other statuses.

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/model/FormValue.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/FormValue.java
@@ -112,4 +112,8 @@ public class FormValue {
     public OptionsFormVal getForm() {
         return form;
     }
+
+    public String getLabel() {
+        return label;
+    }
 }


### PR DESCRIPTION
This supports `authenticator-verification-data` for instance.

This allows us to handle `authenticator-verification-data` from authenticate for example. See https://github.com/okta/okta-idx-android/pull/33