### PR TITLE
fix mfa issue

### DIFF
--- a/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/ResponseHandler.java
+++ b/direct-auth-samples/src/main/java/com/okta/spring/example/helpers/ResponseHandler.java
@@ -98,6 +98,7 @@ public final class ResponseHandler {
             case PASSWORD_EXPIRED:
                 return registerPasswordForm("Password Expired");
             case AWAITING_AUTHENTICATOR_SELECTION:
+            case AWAITING_AUTHENTICATOR_VERIFICATION_DATA:
                 return selectAuthenticatorForm(response, "Select Authenticator", session);
             case AWAITING_AUTHENTICATOR_VERIFICATION:
                 return verifyForm();


### PR DESCRIPTION
### Issue:

If the user has only phone required rule (no email), the sample app fails with "unsupported policy".

(policy config: add the user to MFA Required and Phone Enrollment Required groups). With this config, login of a user would fail with "Unsupported Policy." error. This PR fixes it.