### PR TITLE
Fix register after multiple attempts with invalid email.

### DIFF
--- a/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/LoginController.java
+++ b/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/LoginController.java
@@ -313,8 +313,20 @@ public class LoginController {
                                  final HttpSession session) {
         logger.info(":: Register ::");
 
-        ProceedContext beginProceedContext = Util.getProceedContextFromSession(session);
+        AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin();
+        if (responseHandler.needsToShowErrors(beginResponse)) {
+            ModelAndView modelAndView = new ModelAndView("register");
+            modelAndView.addObject("errors", beginResponse.getErrors());
+            return modelAndView;
+        }
+        ProceedContext beginProceedContext = beginResponse.getProceedContext();
+
         AuthenticationResponse newUserRegistrationResponse = idxAuthenticationWrapper.fetchSignUpFormValues(beginProceedContext);
+        if (responseHandler.needsToShowErrors(newUserRegistrationResponse)) {
+            ModelAndView modelAndView = new ModelAndView("register");
+            modelAndView.addObject("errors", newUserRegistrationResponse.getErrors());
+            return modelAndView;
+        }
 
         if (responseHandler.needsToShowErrors(newUserRegistrationResponse)) {
             ModelAndView mav = new ModelAndView("register");


### PR DESCRIPTION
Due to the way the underlying API works, we can get into a situation where the identify call succeeds, and we have a proceed context that's in the wrong state.

I originally used the begin context from the login page to optimize network calls. But it causes issues due to the way the API/SDK is implemented.

See OKTA-403240