### PR TITLE
Social auth login requires user extra click for interaction code exchange

### DIFF
--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
@@ -17,12 +17,21 @@ package com.okta.spring.example.controllers;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class HomeController {
 
     @GetMapping("/")
-    public String home() {
+    public String home(
+            @RequestParam(name = "interaction_code", required = false) String interactionCode,
+            @RequestParam(name = "state", required = false) String state) {
+
+        if (interactionCode != null && state != null) {
+            String oauthAuthUri =
+                    String.format("/oauth2/authorization/okta?interaction_code=%s&state=%s", interactionCode, state);
+            return "redirect:" + oauthAuthUri;
+        }
         return "home";
     }
 }

--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
@@ -24,12 +24,20 @@ public class HomeController {
 
     @GetMapping("/")
     public String home(
+            @RequestParam(name = "error", required = false) String error,
             @RequestParam(name = "interaction_code", required = false) String interactionCode,
             @RequestParam(name = "state", required = false) String state) {
 
+        //MFA disabled
         if (interactionCode != null && state != null) {
             String oauthAuthUri =
                     String.format("/oauth2/authorization/okta?interaction_code=%s&state=%s", interactionCode, state);
+            return "redirect:" + oauthAuthUri;
+        }
+        //MFA enabled
+        if (state != null && error != null && error.equals("interaction_required")) {
+            String oauthAuthUri =
+                    String.format("/oauth2/authorization/okta?error=%s&state=%s", error, state);
             return "redirect:" + oauthAuthUri;
         }
         return "home";


### PR DESCRIPTION
If `interaction_code` and `state` query args are presented then need to exchange interaction code to a token.