### PR TITLE
fix a "Session expired" error

### DIFF
--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import javax.servlet.http.HttpSession;
+
 @Controller
 public class HomeController {
 
@@ -26,7 +28,8 @@ public class HomeController {
     public String home(
             @RequestParam(name = "error", required = false) String error,
             @RequestParam(name = "interaction_code", required = false) String interactionCode,
-            @RequestParam(name = "state", required = false) String state) {
+            @RequestParam(name = "state", required = false) String state,
+            HttpSession session) {
 
         //MFA disabled
         if (interactionCode != null && state != null) {
@@ -39,6 +42,10 @@ public class HomeController {
             String oauthAuthUri =
                     String.format("/oauth2/authorization/okta?error=%s&state=%s", error, state);
             return "redirect:" + oauthAuthUri;
+        }
+        //cleanup the context in case of unsuccessful login
+        if(error != null && error.equals("access_denied")) {
+            session.setAttribute("idxClientContext", null);
         }
         return "home";
     }

--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/controllers/HomeController.java
@@ -15,6 +15,7 @@
  */
 package com.okta.spring.example.controllers;
 
+import com.okta.commons.lang.Strings;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,7 +45,7 @@ public class HomeController {
             return "redirect:" + oauthAuthUri;
         }
         //cleanup the context in case of unsuccessful login
-        if(error != null && error.equals("access_denied")) {
+        if (Strings.hasText(error)) {
             session.setAttribute("idxClientContext", null);
         }
         return "home";


### PR DESCRIPTION
Cleanup the context in case of unsuccessful login to force the idxClient to do an `interact()` again