### PR TITLE
Clean log

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/client/AuthenticationTransaction.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/AuthenticationTransaction.java
@@ -174,7 +174,7 @@ final class AuthenticationTransaction {
 
         if (idxResponse.isLoginSuccessful()) {
             // login successful
-            logger.info("Login Successful!");
+            logger.debug("Login Successful!");
             TokenResponse tokenResponse = idxResponse.getSuccessWithInteractionCode().exchangeCode(client, clientContext);
             authenticationResponse.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
             authenticationResponse.setTokenResponse(tokenResponse);


### PR DESCRIPTION
Authentication successful events are expected and will create a lot of log spam. Changed to `debug`

Related to https://github.com/okta/okta-idx-java/issues/204