### PR TITLE
Security fix

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
@@ -120,7 +120,7 @@ public class IDXAuthenticationWrapper {
 
                 if (isIdentifyInOneStep) {
                     Credentials credentials = new Credentials();
-                    credentials.setPasscode(authenticationOptions.getPassword().toCharArray());
+                    credentials.setPasscode(authenticationOptions.getPassword());
 
                     identifyRequest = IdentifyRequestBuilder.builder()
                             .withIdentifier(authenticationOptions.getUsername())
@@ -148,7 +148,7 @@ public class IDXAuthenticationWrapper {
             AuthenticationTransaction answerTransaction = passwordTransaction.proceed(() -> {
                 // answer password authenticator challenge
                 Credentials credentials = new Credentials();
-                credentials.setPasscode(authenticationOptions.getPassword().toCharArray());
+                credentials.setPasscode(authenticationOptions.getPassword());
 
                 // build answer password authenticator challenge request
                 AnswerChallengeRequest passwordAuthenticatorAnswerChallengeRequest =

--- a/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationOptions.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationOptions.java
@@ -15,6 +15,8 @@
  */
 package com.okta.idx.sdk.api.model;
 
+import java.util.Arrays;
+
 public class AuthenticationOptions {
 
     private String username;
@@ -35,7 +37,7 @@ public class AuthenticationOptions {
     }
 
     public char[] getPassword() {
-        return password;
+        return Arrays.copyOf(password, password.length);
     }
 
     public void setPassword(char[] password) {

--- a/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationOptions.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationOptions.java
@@ -19,9 +19,9 @@ public class AuthenticationOptions {
 
     private String username;
 
-    private String password;
+    private char[] password;
 
-    public AuthenticationOptions(String username, String password) {
+    public AuthenticationOptions(String username, char[] password) {
         this.username = username;
         this.password = password;
     }
@@ -34,11 +34,11 @@ public class AuthenticationOptions {
         this.username = username;
     }
 
-    public String getPassword() {
+    public char[] getPassword() {
         return password;
     }
 
-    public void setPassword(String password) {
+    public void setPassword(char[] password) {
         this.password = password;
     }
 }

--- a/api/src/test/groovy/com/okta/idx/sdk/api/client/IDXAuthenticationWrapperTest.groovy
+++ b/api/src/test/groovy/com/okta/idx/sdk/api/client/IDXAuthenticationWrapperTest.groovy
@@ -281,7 +281,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -310,7 +310,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("Authentication failed"))
@@ -333,7 +333,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -362,7 +362,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("Password is incorrect"))
@@ -384,7 +384,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -414,7 +414,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -446,7 +446,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("mary@example.com", "superSecret"), beginResponse.proceedContext
+                new AuthenticationOptions("mary@example.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -473,7 +473,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("mary@unknown.com", "superSecret"), beginResponse.proceedContext
+                new AuthenticationOptions("mary@unknown.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("There is no account with the Username mary@unknown.com."))
@@ -500,7 +500,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("mary@example.com", "wrong"), beginResponse.proceedContext
+                new AuthenticationOptions("mary@example.com", "wrong".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("Password is incorrect"))
@@ -524,7 +524,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("mary@example.com", "superSecret"), beginResponse.proceedContext
+                new AuthenticationOptions("mary@example.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("User is not assigned to this application"))
@@ -548,7 +548,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("mary@example.com", "superSecret"), beginResponse.proceedContext
+                new AuthenticationOptions("mary@example.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("Authentication failed"))
@@ -572,7 +572,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("mary@example.com", "superSecret"), beginResponse.proceedContext
+                new AuthenticationOptions("mary@example.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("This factor is suspended for your account due to too many failed attempts"))
@@ -596,7 +596,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("mary@example.com", "superSecret"), beginResponse.proceedContext
+                new AuthenticationOptions("mary@example.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("Authentication failed"))
@@ -620,7 +620,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("Mary@unknown.com", "superSecret"), beginResponse.proceedContext
+                new AuthenticationOptions("Mary@unknown.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), hasItem("There is no account with the Username Mary@unknown.com."))
@@ -1018,7 +1018,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -1090,7 +1090,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -1151,7 +1151,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -1222,7 +1222,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -1281,7 +1281,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())
@@ -1335,7 +1335,7 @@ class IDXAuthenticationWrapperTest {
 
         AuthenticationResponse beginResponse = idxAuthenticationWrapper.begin()
         AuthenticationResponse authenticationResponse = idxAuthenticationWrapper.authenticate(
-                new AuthenticationOptions("username", "password"), beginResponse.proceedContext
+                new AuthenticationOptions("username", "password".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
         assertThat(authenticationResponse.getErrors(), empty())

--- a/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/LoginController.java
+++ b/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/LoginController.java
@@ -78,7 +78,7 @@ public class LoginController {
 
         // trigger authentication
         AuthenticationResponse authenticationResponse =
-                idxAuthenticationWrapper.authenticate(new AuthenticationOptions(username, password), proceedContext);
+                idxAuthenticationWrapper.authenticate(new AuthenticationOptions(username, password.toCharArray()), proceedContext);
 
         if (responseHandler.needsToShowErrors(authenticationResponse)) {
             ModelAndView modelAndView = new ModelAndView("redirect:/login");


### PR DESCRIPTION
Related to https://github.com/okta/okta-idx-java/issues/197

- Password represented as a char[]
- NPE [credentials.setPasscode(authenticationOptions.getPassword().toCharArray())](https://github.com/okta/okta-idx-java/blob/a4f0442bcfd4bf4e91c4abc552b6799d7ae3775b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java#L123) solved