### PR TITLE
Hidden error

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/client/AuthenticationTransaction.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/AuthenticationTransaction.java
@@ -67,6 +67,7 @@ final class AuthenticationTransaction {
     static AuthenticationTransaction proceed(IDXClient client, ProceedContext proceedContext, Factory factory) throws ProcessingException {
         IDXResponse idxResponse = factory.create();
         WrapperUtil.printRemediationOptions(idxResponse);
+        WrapperUtil.printMessage(idxResponse);
         return new AuthenticationTransaction(client, proceedContext.getClientContext(), idxResponse);
     }
 
@@ -152,6 +153,7 @@ final class AuthenticationTransaction {
     AuthenticationTransaction proceed(Factory factory) throws ProcessingException {
         IDXResponse idxResponse = factory.create();
         WrapperUtil.printRemediationOptions(idxResponse);
+        WrapperUtil.printMessage(idxResponse);
         return new AuthenticationTransaction(client, clientContext, idxResponse);
     }
 

--- a/api/src/main/java/com/okta/idx/sdk/api/client/WrapperUtil.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/WrapperUtil.java
@@ -72,4 +72,11 @@ final class WrapperUtil {
             logger.debug("Remediation options unavailable");
         }
     }
+
+    static void printMessage(IDXResponse idxResponse) {
+        if(idxResponse != null && idxResponse.getMessages() != null && idxResponse.getMessages().hasErrorValue()) {
+            Arrays.stream(idxResponse.getMessages().getValue())
+                    .forEach(messageValue -> logger.error(messageValue.getMessage()));
+        }
+    }
 }


### PR DESCRIPTION
Making a request to `IDXAuthenticationWrapper.begin()` when Authorization Server is not configured for `Interaction Code` hides error

Origin: https://github.com/okta/okta-idx-java/issues/201