### PR TITLE
Fix for inability to skip 'enroll Authenticator' step during self-registration

### DIFF
--- a/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/HomeController.java
+++ b/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/HomeController.java
@@ -202,8 +202,12 @@ public class HomeController {
             return homeHelper.proceedToHome(tokenResponse, session);
         }
 
+        ProceedContext proceedContext = Util.getProceedContextFromSession(session);
+        boolean canSkip = authenticationWrapper.isSkipAuthenticatorPresent(proceedContext);
+
         ModelAndView modelAndView = new ModelAndView("select-authenticator");
         modelAndView.addObject("title", "Select Authenticator");
+        modelAndView.addObject("canSkip", canSkip);
         modelAndView.addObject("authenticators", authenticators);
         return modelAndView;
     }

--- a/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/LoginController.java
+++ b/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/controllers/LoginController.java
@@ -136,9 +136,20 @@ public class LoginController {
                                             final @RequestParam(value = "action") String action,
                                             final HttpSession session) {
 
+        AuthenticationResponse authenticationResponse = null;
+        Authenticator foundAuthenticator = null;
+
         ProceedContext proceedContext = Util.getProceedContextFromSession(session);
+
+        if ("skip".equals(action)) {
+            logger.info("Skipping {} authenticator", authenticatorType);
+            authenticationResponse = idxAuthenticationWrapper.skipAuthenticatorEnrollment(proceedContext);
+            return responseHandler.handleKnownTransitions(authenticationResponse, session);
+        }
+
         List<Authenticator> authenticators = (List<Authenticator>) session.getAttribute("authenticators");
-        if (authenticatorType != null && authenticatorType.equals("webauthn")) {
+
+        if ("webauthn".equals(authenticatorType)) {
             ModelAndView modelAndView;
 
             Optional<Authenticator> authenticatorOptional =
@@ -165,16 +176,6 @@ public class LoginController {
             }
             return modelAndView;
         }
-
-        AuthenticationResponse authenticationResponse = null;
-
-        if ("skip".equals(action)) {
-            logger.info("Skipping {} authenticator", authenticatorType);
-            authenticationResponse = idxAuthenticationWrapper.skipAuthenticatorEnrollment(proceedContext);
-            return responseHandler.handleKnownTransitions(authenticationResponse, session);
-        }
-
-        Authenticator foundAuthenticator = null;
 
         for (Authenticator authenticator : authenticators) {
             if (authenticatorType.equals(authenticator.getType())) {


### PR DESCRIPTION
Add missing functionality to HomeController.
The action variable analysis should be performed before any other logic.