### PR TITLE
Update "OIDC Web Application Setup Instructions" link

### DIFF
--- a/samples/embedded-sign-in-widget/README.md
+++ b/samples/embedded-sign-in-widget/README.md
@@ -79,5 +79,5 @@ You can login with the same account that you created when signing up for your De
 > **NOTE:** You should use an incognito tab to test the flow from a blank slate.
 
 [Okta Spring Boot Library]: https://github.com/okta/okta-spring-boot
-[OIDC Web Application Setup Instructions]: https://developer.okta.com/authentication-guide/implementing-authentication/auth-code#1-setting-up-your-application
+[OIDC Web Application Setup Instructions]: https://developer.okta.com/docs/guides/implement-grant-type/authcode/main/#set-up-your-app
 [Okta Sign In Widget]: https://github.com/okta/okta-signin-widget


### PR DESCRIPTION
This link was not 404'ing, but the fragment being redirected to was not correct, so the topof thepage was shown, and not the relevant section. This PR fixes that.