### PR TITLE
 stop deploying snapshot builds from travis

### DIFF
--- a/src/ci/build.sh
+++ b/src/ci/build.sh
@@ -34,8 +34,8 @@ deploy () {
     echo "Downloading chromedriver"
     "${CHROMEDRIVER_DOWNLOAD_SCRIPT}"
 
-    echo "Deploying SNAPSHOT build"
-    ${MVN_CMD} deploy -Pci
+    echo "Running mvn verify"
+    ${MVN_CMD} verify -Pci
 
     # also deploy the javadocs to the site
     git clone -b gh-pages "https://github.com/${REPO_SLUG}.git" target/gh-pages/


### PR DESCRIPTION
Similar to https://github.com/okta/okta-sdk-java/pull/641