### PR TITLE
Rename ClientUtil.getNormalizeUri() to ClientUril.normalizeIssuerUri to avoid confusion

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/client/BaseIDXClient.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/BaseIDXClient.java
@@ -58,13 +58,12 @@ import com.okta.idx.sdk.api.util.PkceUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.okta.idx.sdk.api.util.ClientUtil.getNormalizedUri;
+import static com.okta.idx.sdk.api.util.ClientUtil.normalizedIssuerUri;
 
 final class BaseIDXClient implements IDXClient {
 
@@ -136,7 +135,7 @@ final class BaseIDXClient implements IDXClient {
 
             Request request = new DefaultRequest(
                 HttpMethod.POST,
-                getNormalizedUri(clientConfiguration.getIssuer(), "/v1/interact"),
+                normalizedIssuerUri(clientConfiguration.getIssuer(), "/v1/interact"),
                 null,
                 httpHeaders,
                 new ByteArrayInputStream(urlParameters.toString().getBytes(StandardCharsets.UTF_8)),
@@ -531,14 +530,14 @@ final class BaseIDXClient implements IDXClient {
         try {
             Request request = new DefaultRequest(
                     HttpMethod.POST,
-                    getNormalizedUri(clientConfiguration.getIssuer(), "/v1/revoke"),
+                    normalizedIssuerUri(clientConfiguration.getIssuer(), "/v1/revoke"),
                     null,
                     getHttpHeaders(true),
                     new ByteArrayInputStream(urlParameters.toString().getBytes(StandardCharsets.UTF_8)),
                     -1L);
 
             requestExecutor.executeRequest(request);
-        } catch (HttpException | MalformedURLException e) {
+        } catch (HttpException e) {
             throw new ProcessingException(e);
         }
     }

--- a/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/IDXAuthenticationWrapper.java
@@ -62,7 +62,6 @@ import com.okta.idx.sdk.api.util.ClientUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -862,13 +861,11 @@ public class IDXAuthenticationWrapper {
 
         try {
             TokenResponse tokenResponse =
-                    client.token(ClientUtil.getNormalizedUri(issuer, "/v1/token"),
+                    client.token(ClientUtil.normalizedIssuerUri(issuer, "/v1/token"),
                             "interaction_code", interactionCode, proceedContext.getClientContext());
             authenticationResponse.setTokenResponse(tokenResponse);
         } catch (ProcessingException e) {
             return handleProcessingException(e);
-        } catch (MalformedURLException e) {
-            logger.error("Error occurred", e);
         }
 
         return authenticationResponse;

--- a/api/src/main/java/com/okta/idx/sdk/api/util/ClientUtil.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/util/ClientUtil.java
@@ -32,9 +32,23 @@ public class ClientUtil {
      * @param issuer the issuer url
      * @param resourceUri the uri of resource
      * @return the normalized full url
-     * @throws MalformedURLException if the issuer URi is malformed
+     * @throws IllegalArgumentException if the issuer URi is malformed
+     * @deprecated This method has been renamed to getNormalizedIssuerUri
      */
+    @Deprecated
     public static String getNormalizedUri(String issuer, String resourceUri) throws MalformedURLException {
+        return normalizedIssuerUri(issuer, resourceUri);
+    }
+
+    /**
+     * Construct the normalized URL given an issuer and a resource uri.
+     *
+     * @param issuer the issuer url
+     * @param resourceUri the uri of resource
+     * @return the normalized full url
+     * @throws IllegalArgumentException if the issuer URi is malformed
+     */
+    public static String normalizedIssuerUri(String issuer, String resourceUri) {
         // remove trailing forward slash
         String normalizedUri = issuer.replaceAll("$/", "");
 
@@ -59,23 +73,26 @@ public class ClientUtil {
      *
      * @param issuerUri the issuer uri
      * @return true if root/org, false otherwise
-     * @throws MalformedURLException if the issuer uri is invalid
      */
-    public static boolean isRootOrgIssuer(String issuerUri) throws MalformedURLException {
-        String uriPath = new URL(issuerUri).getPath();
+    public static boolean isRootOrgIssuer(String issuerUri) {
+        try {
+            String uriPath = new URL(issuerUri).getPath();
 
-        if (Strings.hasText(uriPath)) {
-            String[] tokenizedUri = uriPath.substring(uriPath.indexOf("/")+1).split("/");
+            if (Strings.hasText(uriPath)) {
+                String[] tokenizedUri = uriPath.substring(uriPath.indexOf("/") + 1).split("/");
 
-            if (tokenizedUri.length >= 2 &&
+                if (tokenizedUri.length >= 2 &&
                     "oauth2".equals(tokenizedUri[0]) &&
                     Strings.hasText(tokenizedUri[1])) {
-                logger.debug("The issuer URL: '{}' is an Okta custom authorization server", issuerUri);
-                return false;
+                    logger.debug("The issuer URL: '{}' is an Okta custom authorization server", issuerUri);
+                    return false;
+                }
             }
-        }
 
-        logger.debug("The issuer URL: '{}' is an Okta root/org authorization server", issuerUri);
-        return true;
+            logger.debug("The issuer URL: '{}' is an Okta root/org authorization server", issuerUri);
+            return true;
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Issuer URL was not a valid URL", e);
+        }
     }
 }

--- a/api/src/test/groovy/com/okta/idx/sdk/api/client/BaseIDXClientTest.groovy
+++ b/api/src/test/groovy/com/okta/idx/sdk/api/client/BaseIDXClientTest.groovy
@@ -58,7 +58,7 @@ import org.testng.annotations.Test
 
 import java.util.stream.Collectors
 
-import static com.okta.idx.sdk.api.util.ClientUtil.getNormalizedUri
+import static com.okta.idx.sdk.api.util.ClientUtil.normalizedIssuerUri
 
 import static org.hamcrest.Matchers.arrayWithSize
 import static org.hamcrest.Matchers.is
@@ -1193,7 +1193,7 @@ class BaseIDXClientTest {
         try {
             idxClient.interact()
         } catch (ProcessingException e) {
-            String interactUrl = getNormalizedUri(clientConfiguration.getIssuer(),"/v1/interact")
+            String interactUrl = normalizedIssuerUri(clientConfiguration.getIssuer(),"/v1/interact")
             assertThat(e.getHttpStatus(), is(400))
             assertThat(e.getMessage(), is("Request to " + interactUrl + " failed. HTTP status: 400"))
             assertThat(e.getErrorResponse(), notNullValue())
@@ -1281,7 +1281,7 @@ class BaseIDXClientTest {
         try {
             idxClient.interact()
         } catch (ProcessingException e) {
-            String interactUrl = getNormalizedUri(clientConfiguration.getIssuer(),"/v1/interact")
+            String interactUrl = normalizedIssuerUri(clientConfiguration.getIssuer(),"/v1/interact")
             assertThat(e.getHttpStatus(), is(500))
             assertThat(e.getMessage(), is("Request to " + interactUrl + " failed. HTTP status: 500"))
         }

--- a/api/src/test/groovy/com/okta/idx/sdk/api/util/ClientUtilTest.groovy
+++ b/api/src/test/groovy/com/okta/idx/sdk/api/util/ClientUtilTest.groovy
@@ -25,10 +25,10 @@ class ClientUtilTest {
     @Test
     void testNormalizedUrl() {
         // root org issuer
-        assertThat(ClientUtil.getNormalizedUri("https://foo.oktapreview.com", "/v1/interact"),
+        assertThat(ClientUtil.normalizedIssuerUri("https://foo.oktapreview.com", "/v1/interact"),
                 is("https://foo.oktapreview.com/oauth2/v1/interact"))
         // non root org issuer
-        assertThat(ClientUtil.getNormalizedUri("https://foo.oktapreview.com/oauth2/default", "/v1/interact"),
+        assertThat(ClientUtil.normalizedIssuerUri("https://foo.oktapreview.com/oauth2/default", "/v1/interact"),
                 is("https://foo.oktapreview.com/oauth2/default/v1/interact"))
     }
 

--- a/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
+++ b/samples/embedded-auth-with-sdk/src/main/java/com/okta/spring/example/helpers/HomeHelper.java
@@ -34,7 +34,7 @@ import javax.servlet.http.HttpSession;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static com.okta.idx.sdk.api.util.ClientUtil.getNormalizedUri;
+import static com.okta.idx.sdk.api.util.ClientUtil.normalizedIssuerUri;
 
 @Component
 public class HomeHelper {
@@ -74,7 +74,7 @@ public class HomeHelper {
 
         try {
             // get user claim info from /v1/userinfo endpoint
-            String userInfoUrl = getNormalizedUri(issuer, "/v1/userinfo");
+            String userInfoUrl = normalizedIssuerUri(issuer, "/v1/userinfo");
 
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.setBearerAuth(tokenResponse.getAccessToken());

--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/HelperUtil.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/HelperUtil.java
@@ -95,7 +95,7 @@ public class HelperUtil {
 
         final HttpEntity<MultiValueMap<String, String>> requestEntity =
                 new HttpEntity<>(requestParams, headers);
-        final String tokenUri = ClientUtil.getNormalizedUri(issuer, "/v1/token");
+        final String tokenUri = ClientUtil.normalizedIssuerUri(issuer, "/v1/token");
 
         final ResponseEntity<JsonNode> responseEntity =
                 restTemplate.postForEntity(tokenUri, requestEntity, JsonNode.class);


### PR DESCRIPTION
At first glance it may appear that `getNormalizeUri` will normalize any URL, but it ONLY works for issuer URIs
