### PR TITLE
fix java 17 build issue

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -43,7 +43,6 @@ This project includes:
   Okta Spring Boot :: OAuth2 under The Apache License, Version 2.0
   Okta Spring Boot :: SDK under The Apache License, Version 2.0
   Okta Spring Boot :: Starter under The Apache License, Version 2.0
-  SLF4J API Module under MIT License
   SnakeYAML under Apache License, Version 2.0
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>21</version>
+        <version>23</version>
     </parent>
 
     <groupId>com.okta.idx.sdk</groupId>
@@ -215,7 +215,7 @@
                         <trimStackTrace>false</trimStackTrace>
                         <reuseForks>true</reuseForks>
                         <forkCount>1</forkCount>
-                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+<!--                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>-->
 <!--                        <parallel>classesAndMethods</parallel>-->
 <!--                        <threadCount>5</threadCount>-->
 <!--                        <skipTests>${skipImplTests}</skipTests>-->


### PR DESCRIPTION
- Upgrade to Java parent v23.
- Fix Java 17 build issue (https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#removed-java-options).