### PR TITLE
Include i18n messages in AuthenticationResponse object

### DIFF
--- a/api/src/main/java/com/okta/idx/sdk/api/client/AuthenticationTransaction.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/client/AuthenticationTransaction.java
@@ -17,6 +17,7 @@ package com.okta.idx.sdk.api.client;
 
 import com.okta.commons.http.Response;
 import com.okta.commons.lang.Assert;
+import com.okta.commons.lang.Strings;
 import com.okta.idx.sdk.api.exception.ProcessingException;
 import com.okta.idx.sdk.api.model.AuthenticationStatus;
 import com.okta.idx.sdk.api.model.CurrentAuthenticatorEnrollment;
@@ -309,7 +310,13 @@ final class AuthenticationTransaction {
             return;
         }
         Arrays.stream(idxResponse.getMessages().getValue())
-                .forEach(msg -> authenticationResponse.addError(msg.getMessage()));
+                .forEach(msg -> {
+                    String message = msg.getMessage();
+                    if (msg.getI18NMessage() != null && Strings.hasText(msg.getI18NMessage().getKey())) {
+                        message += ", " + msg.getI18NMessage();
+                    }
+                    authenticationResponse.addError(message);
+                });
     }
 
     private void fillOutAuthenticators(AuthenticationResponse authenticationResponse) {

--- a/api/src/main/java/com/okta/idx/sdk/api/model/I18NMessage.java
+++ b/api/src/main/java/com/okta/idx/sdk/api/model/I18NMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-Present, Okta, Inc.
+ * Copyright (c) 2023-Present, Okta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,35 +15,27 @@
  */
 package com.okta.idx.sdk.api.model;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
+import java.util.List;
+
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public class MessageValue {
+public class I18NMessage {
 
-    private String message;
+    private String key;
 
-    @JsonAlias("i18n")
-    private I18NMessage i18NMessage;
-    @JsonAlias("class")
-    private String value;
+    private List<String> params;
 
-    public String getMessage() {
-        return message;
+    public String getKey() {
+        return key;
     }
 
-    public I18NMessage getI18NMessage() {
-        return i18NMessage;
-    }
-
-    public String getValue() {
-        return value;
+    public List<String> getParams() {
+        return params;
     }
 
     @Override
     public String toString() {
-        return "message='" + message + '\'' +
-                ", i18n=" + i18NMessage +
-                ", value='" + value + '\'';
+        return "key='" + key + '\'' + ", params=" + params;
     }
 }

--- a/api/src/test/groovy/com/okta/idx/sdk/api/client/IDXAuthenticationWrapperTest.groovy
+++ b/api/src/test/groovy/com/okta/idx/sdk/api/client/IDXAuthenticationWrapperTest.groovy
@@ -689,7 +689,8 @@ class IDXAuthenticationWrapperTest {
                 new AuthenticationOptions("mary@unknown.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
-        assertThat(authenticationResponse.getErrors(), hasItem("There is no account with the Username mary@unknown.com."))
+        assertThat(authenticationResponse.getErrors(),
+                hasItem("There is no account with the Username mary@unknown.com., key='idx.unknown.user', params=[]"))
         assertThat(authenticationResponse.getAuthenticationStatus(),
                 is(AuthenticationStatus.UNKNOWN)
         )
@@ -877,7 +878,8 @@ class IDXAuthenticationWrapperTest {
                 new AuthenticationOptions("Mary@unknown.com", "superSecret".toCharArray()), beginResponse.proceedContext
         )
         assertThat(authenticationResponse, notNullValue())
-        assertThat(authenticationResponse.getErrors(), hasItem("There is no account with the Username Mary@unknown.com."))
+        assertThat(authenticationResponse.getErrors(),
+                hasItem("There is no account with the Username Mary@unknown.com., key='idx.unknown.user', params=[]"))
         assertThat(authenticationResponse.getAuthenticators(), nullValue())
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <properties>
         <jackson.version>2.15.2</jackson.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <okta.commons.version>1.3.1</okta.commons.version>
-        <okta.sdk.previousVersion>3.0.3</okta.sdk.previousVersion>
+        <okta.commons.version>1.3.4</okta.commons.version>
+        <okta.sdk.previousVersion>3.0.4</okta.sdk.previousVersion>
         <org.apache.tomcat.embed.version>9.0.76</org.apache.tomcat.embed.version>
         <org.jetbrains.kotlin.version>1.6.10</org.jetbrains.kotlin.version>
         <github.slug>okta/okta-idx-java</github.slug>
@@ -252,6 +252,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
+                    <version>8.3.1</version>
                     <configuration>
                         <!-- no js is used in this project -->
                         <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>

--- a/samples/embedded-sign-in-widget/pom.xml
+++ b/samples/embedded-sign-in-widget/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.19</version>
+            <version>9.30.2</version>
         </dependency>
 
         <!-- These are the selenium dependencies -->

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -25,7 +25,6 @@
     </parent>
 
     <artifactId>okta-idx-java-samples</artifactId>
-    <groupId>com.okta.idx.sdk</groupId>
     <name>Okta IDX Java SDK :: Samples</name>
     <packaging>pom</packaging>
 
@@ -34,14 +33,4 @@
         <module>embedded-sign-in-widget</module>
     </modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.13.3</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>
-


### PR DESCRIPTION
https://github.com/okta/okta-idx-java/issues/439

OKTA-595550

- AuthenticationREsponse will now contain i18n messages that were sent by Okta Backend in IDXResponse.
- Few dependency upgrades.