### PR TITLE
cve fix: bump org.thymeleaf from 3.0.15 to 3.1.2.RELEASE

### DIFF
--- a/samples/embedded-auth-with-sdk/pom.xml
+++ b/samples/embedded-auth-with-sdk/pom.xml
@@ -74,6 +74,11 @@
             <version>${spring.boot.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.1.2.RELEASE</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <version>${spring.boot.version}</version>

--- a/samples/embedded-sign-in-widget/pom.xml
+++ b/samples/embedded-sign-in-widget/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot.version>2.7.12</spring.boot.version>
+        <spring.boot.version>2.7.15</spring.boot.version>
         <okta.springboot.starter.version>2.1.5</okta.springboot.starter.version>
         <java.version>1.8</java.version>
         <okta.sdk.api.version>8.2.2</okta.sdk.api.version>
@@ -77,6 +77,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
             <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.1.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>


### PR DESCRIPTION
OKTA-634944

- Bump `org.thymeleaf:thymeleaf` from `3.0.15.RELEASE` to `3.1.2.RELEASE`
- Bump springboot from `2.7.12` to `2.7.15`
