### PR TITLE
Upgrade tomcat-embed-core to 11.0.6 to address Snyk vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>11.0.3</version>
+                <version>11.0.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR upgrades the `org.apache.tomcat.embed:tomcat-embed-core` dependency from version `11.0.3` to `11.0.6` to address critical security vulnerabilities identified by Snyk
