### PR TITLE
OKTA-959507 - bumping tomcat-embed-core to 11.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>11.0.6</version>
+                <version>11.0.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR updates the org.springframework.security dependency from version from 11.0.6 to 11.0.8 to remediate multiple vulnerabilities identified by Snyk.