### PR TITLE
Upgrade tomcat-embed-core to 11.0.9 to fix CVE-2025-52520 and CVE-2025-53506

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>11.0.8</version>
+                <version>11.0.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR resolves two high-severity vulnerabilities identified by Snyk in `tomcat-embed-core@11.0.8`
