### PR TITLE
Update Embedded Widget Sample for Springboot 3.x and thymeleaf-extras-springsecurity6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,8 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
                 <version>11.0.9</version>
+                <!-- use 10.1.34 if running the embedded Widget sample -->
+                <!--version>10.1.34</version-->
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/samples/embedded-sign-in-widget/pom.xml
+++ b/samples/embedded-sign-in-widget/pom.xml
@@ -85,12 +85,12 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>3.1.2.RELEASE</version>
+            <version>3.1.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
-            <artifactId>thymeleaf-extras-springsecurity5</artifactId>
-            <version>3.1.2.RELEASE</version>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+            <version>3.1.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/CustomAuthenticationProcessingFilter.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/CustomAuthenticationProcessingFilter.java
@@ -39,8 +39,11 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResp
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.util.UrlUtils;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -53,11 +56,12 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
+
+
 @SuppressWarnings("PMD")
 public class CustomAuthenticationProcessingFilter extends AbstractAuthenticationProcessingFilter {
 
-    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository =
-            new HttpSessionOAuth2AuthorizationRequestRepository();
+    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = new HttpSessionOAuth2AuthorizationRequestRepository();
 
     private ClientRegistrationRepository clientRegistrationRepository;
 
@@ -139,10 +143,21 @@ public class CustomAuthenticationProcessingFilter extends AbstractAuthentication
                 oauth2User, authenticationResult.getAuthorities(),
                 authenticationResult.getClientRegistration().getRegistrationId());
         oauth2Authentication.setDetails(authenticationDetails);
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(oauth2Authentication);
+        SecurityContextHolder.setContext(context);
+        request.getSession().setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, SecurityContextHolder.getContext());
+        request.getSession().setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
+
         return oauth2Authentication;
     }
 
     public void setClientRegistrationRepository(final ClientRegistrationRepository clientRegistrationRepository) {
         this.clientRegistrationRepository = clientRegistrationRepository;
+    }
+
+    public AuthorizationRequestRepository getAuthorizationRequestRepository() {
+        return this.authorizationRequestRepository;
     }
 }

--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/HostedLoginCodeFlowExampleApplication.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/HostedLoginCodeFlowExampleApplication.java
@@ -36,6 +36,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Arrays;
 import java.util.HashSet;
 
+
 /**
  * This example renders a self-hosted login page (hosted within this application). You can use a standard login with less
  * code (if you don't need to customize the login page) see the 'basic' example at the root of this repository.

--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/OAuth2SecurityConfigurerAdapter.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/OAuth2SecurityConfigurerAdapter.java
@@ -27,6 +27,10 @@ import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationF
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 
+
+//import org.springframework.security.oauth2.client.web.*;
+//import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
 @Configuration
 public class OAuth2SecurityConfigurerAdapter {
 
@@ -41,18 +45,26 @@ public class OAuth2SecurityConfigurerAdapter {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
+        CustomAuthenticationProcessingFilter customAuthenticationProcessingFilter = customAuthenticationProcessingFilter(http);;
+
         http
                 .exceptionHandling(ex -> ex.accessDeniedHandler((req, res, e) -> res.sendRedirect("/403")))
                 .addFilterBefore(customAuthenticationProcessingFilter(http), OAuth2LoginAuthenticationFilter.class)
                 .authorizeHttpRequests((authz) -> authz
-                        .requestMatchers("/logout").permitAll()
-                        .requestMatchers("/home").permitAll()
-                        .requestMatchers("/hello").permitAll()
+                        .requestMatchers("/", "/custom-login", "/magic-link/callback", "/css/**", "/logout").permitAll()
                         .anyRequest().authenticated()
                 )
                 .logout((logout) -> logout.logoutSuccessUrl("/"))
                 .oauth2Client(Customizer.withDefaults())
-                .oauth2Login(r -> r.redirectionEndpoint(re -> re.baseUri("/authorization-code/callback*")));
+                //.oauth2Login(r -> r.redirectionEndpoint(re -> re.baseUri("/authorization-code/callback*")));
+                .oauth2Login(r -> r
+                    .redirectionEndpoint(re -> re
+                        .baseUri("/authorization-code/callback*")
+                    )
+                    .authorizationEndpoint(authorization -> authorization
+                        .authorizationRequestRepository(customAuthenticationProcessingFilter.getAuthorizationRequestRepository())
+                    )
+                );
 
         return http.build();
     }


### PR DESCRIPTION
Update Sample Embedded Widget for,
Springboot 3.x (Spring Security 6.x)

Fix issue with `AuthorizationRequestRepository` not returning Authorization Request
Fix issue with Too Many Redirects loading App
Fix issue with Spring Security Context not getting set with user Authentication (Didn't need to do this with Spring Boot 2.7.x, Spring Security Bug?)

Update parent `pom.xml` to instruct using tomcat embedded 10.x if running the Sample Embedded Widget