### PR TITLE
Upgrade spring-security-web to 6.5.9 to fix CVE-2026-22732

### DIFF
--- a/samples/embedded-auth-with-sdk/pom.xml
+++ b/samples/embedded-auth-with-sdk/pom.xml
@@ -32,12 +32,20 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <checkstyle-maven-plugin.version>3.1.2</checkstyle-maven-plugin.version>
         <spring.boot.version>3.3.7</spring.boot.version>
+        <spring-security.version>6.5.9</spring-security.version>
         <java.version>1.8</java.version>
         <okta.sdk.api.version>8.2.2</okta.sdk.api.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>${spring-security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/samples/embedded-sign-in-widget/pom.xml
+++ b/samples/embedded-sign-in-widget/pom.xml
@@ -32,12 +32,20 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring.boot.version>3.3.7</spring.boot.version>
         <okta.springboot.starter.version>3.0.7</okta.springboot.starter.version>
+        <spring-security.version>6.5.9</spring-security.version>
         <java.version>1.8</java.version>
         <okta.sdk.api.version>8.2.2</okta.sdk.api.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>${spring-security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -110,7 +118,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>6.4.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/OAuth2SecurityConfigurerAdapter.java
+++ b/samples/embedded-sign-in-widget/src/main/java/com/okta/spring/example/OAuth2SecurityConfigurerAdapter.java
@@ -45,7 +45,7 @@ public class OAuth2SecurityConfigurerAdapter {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        CustomAuthenticationProcessingFilter customAuthenticationProcessingFilter = customAuthenticationProcessingFilter(http);;
+        CustomAuthenticationProcessingFilter customAuthenticationProcessingFilter = customAuthenticationProcessingFilter(http);
 
         http
                 .exceptionHandling(ex -> ex.accessDeniedHandler((req, res, e) -> res.sendRedirect("/403")))


### PR DESCRIPTION
  ---
  Title: Upgrade spring-security-web to 6.5.9 to fix CVE-2026-22732

  Body:
  ## Summary
  - Upgrades `spring-security-web` from 6.3.6 to 6.5.9 by importing the Spring Security BOM in both sample modules
  - Fixes [SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-15701796](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-15701796) — CVE-2026-22732 (CVSS 9.3, Use of Cache Containing Sensitive Information)
  - Removes the hardcoded `spring-security-crypto:6.4.4` override in the embedded-sign-in-widget sample (now managed by the BOM)

  **Jira:** [OKTA-1137811](https://oktainc.atlassian.net/browse/OKTA-1137811)

  ## Test plan
  - [x] Verified `mvn clean compile` succeeds for both sample modules