### PR TITLE
Upgrade Thymeleaf to 3.1.5.RELEASE to fix CVE-2026-40477, CVE-2026-40478, CVE-2026-41901

### DIFF
--- a/samples/embedded-auth-with-sdk/pom.xml
+++ b/samples/embedded-auth-with-sdk/pom.xml
@@ -40,6 +40,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.thymeleaf</groupId>
+                <artifactId>thymeleaf-spring6</artifactId>
+                <version>3.1.5.RELEASE</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-bom</artifactId>
                 <version>${spring-security.version}</version>
@@ -79,7 +84,7 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>3.1.2.RELEASE</version>
+            <version>3.1.5.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/embedded-sign-in-widget/pom.xml
+++ b/samples/embedded-sign-in-widget/pom.xml
@@ -40,6 +40,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.thymeleaf</groupId>
+                <artifactId>thymeleaf-spring6</artifactId>
+                <version>3.1.5.RELEASE</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-bom</artifactId>
                 <version>${spring-security.version}</version>
@@ -93,12 +98,12 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>3.1.3.RELEASE</version>
+            <version>3.1.5.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity6</artifactId>
-            <version>3.1.3.RELEASE</version>
+            <version>3.1.5.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Upgrades thymeleaf, thymeleaf-spring6, and thymeleaf-extras-springsecurity6 to 3.1.5.RELEASE in both sample apps. Adds thymeleaf-spring6 to dependencyManagement in each pom to override the version pinned by the spring-boot-dependencies:3.3.7 BOM.

RESOLVES: OKTA-1178057, OKTA-1158090, OKTA-1158091, OKTA-1158733, OKTA-1158734