### PR TITLE
Upgrade spring-boot to 3.5.14 to fix CVE-2026-40971 and CVE-2026-40974

### DIFF
--- a/samples/embedded-auth-with-sdk/pom.xml
+++ b/samples/embedded-auth-with-sdk/pom.xml
@@ -31,7 +31,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <checkstyle-maven-plugin.version>3.1.2</checkstyle-maven-plugin.version>
-        <spring.boot.version>3.3.7</spring.boot.version>
+        <spring.boot.version>3.5.14</spring.boot.version>
         <spring-security.version>6.5.9</spring-security.version>
         <java.version>1.8</java.version>
         <okta.sdk.api.version>8.2.2</okta.sdk.api.version>
@@ -227,7 +227,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.3.4</version>
+                <version>3.5.14</version>
             </plugin>
             <!-- Force not to run Cucumber tests without cucumber-it profile -->
             <plugin>

--- a/samples/embedded-sign-in-widget/pom.xml
+++ b/samples/embedded-sign-in-widget/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot.version>3.3.7</spring.boot.version>
+        <spring.boot.version>3.5.14</spring.boot.version>
         <okta.springboot.starter.version>3.0.7</okta.springboot.starter.version>
         <spring-security.version>6.5.9</spring-security.version>
         <java.version>1.8</java.version>
@@ -261,7 +261,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.3.4</version>
+                <version>3.5.14</version>
                 <configuration>
                     <fork>false</fork>
                 </configuration>
@@ -427,7 +427,7 @@
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
-                        <version>2.7.8</version>
+                        <version>3.5.14</version>
                         <configuration>
                             <fork>false</fork>
                         </configuration>


### PR DESCRIPTION
Upgrades spring-boot-autoconfigure from 3.3.7 to
3.5.14 in both sample modules by bumping spring.boot.version, addressing two critical (CVSS 9.1 and 9.8) certificate host mismatch vulnerabilities. Also aligns spring-boot-maven-plugin to 3.5.14.

RESOLVES: OKTA-1179331